### PR TITLE
Add a small README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # mir-algorithm
+
+This repo is WIP.
+
+If you are looking for `ndslice`, please go to [the main repo](https://github.com/libmir/mir) for now.
+
+If you want to help, please browse the open issues or [join our Gitter chat](https://gitter.im/libmir/public).


### PR DESCRIPTION
As the deprecation for ndslice was merged and it redirects to this repo
-> Adding a small README so that a user isn't entirely lost.