### PR TITLE
Fixed typo.

### DIFF
--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -148,7 +148,7 @@ Slice!(SliceKind.canonical, packs, Iterator)
 }
 
 Slice!(SliceKind.continuous, packs, Iterator)
-    assumeContinious
+    assumeContinuous
     (SliceKind kind, size_t[] packs, Iterator)
     (Slice!(kind, packs, Iterator) slice)
 {


### PR DESCRIPTION
Also, have you considered using **contiguous** instead of **continuous**? It might be more correct to use contiguous for this occasion.