### PR TITLE
Escape ndslice for ddoc

### DIFF
--- a/source/mir/ndslice/package.d
+++ b/source/mir/ndslice/package.d
@@ -68,7 +68,7 @@ assert(matrix[2, 3] == 6); // D & C index order
 ------
 
 Note:
-In many examples $(REF iota, mir,ndslice,topology) is used
+In many examples $(REF iota, mir,_ndslice,topology) is used
 instead of a regular array, which makes it
 possible to carry out tests without memory allocation.
 


### PR DESCRIPTION
If I understand it correctly, this should fix the following ddoc issue:

![image](https://cloud.githubusercontent.com/assets/4370550/24202362/19d3693a-0f13-11e7-8794-1b8cd008e99d.png)

http://docs.algorithm.dlang.io/latest/mir_ndslice.html