### PR TITLE
Update algorithm.d so equal has default pred

### DIFF
--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -1334,7 +1334,7 @@ Compares two or more slices for equality, as defined by predicate `pred`.
 Params:
     pred = The predicate.
 +/
-template equal(alias pred)
+template equal(alias pred = "a == b")
 {
     import mir.functional: naryFun;
     static if (__traits(isSame, naryFun!pred, pred))


### PR DESCRIPTION
The default argument for equal's pred template argument could be "a == b" so that it can be called more easily.