### PR TITLE
Update algorithm.d equal documentation

### DIFF
--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -1386,7 +1386,7 @@ template equal(alias pred)
 
     assert(equal!"a == b"(sl1, sl1));
     assert(sl1 == sl1); //can also use opEquals for two Slices
-    assert(equal!"a == b"(sl1, sl1, sl1));
+    assert(equal!"2 * a == b + c"(sl1, sl1, sl1));
     
     assert(equal!"a < b"(sl1, sl2));
 

--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -1383,6 +1383,9 @@ template equal(alias pred)
     auto sl2 = iota([2, 3], 1);
 
     assert(equal!"a == b"(sl1, sl1));
+    assert(sl1 == sl1); //can also use opEquals for two Slices
+    assert(equal!"a == b"(sl1, sl1, sl1));
+    
     assert(equal!"a < b"(sl1, sl2));
 
     assert(!equal!"a == b"(sl1[0 .. $ - 1], sl1));

--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -1331,6 +1331,8 @@ unittest
 /++
 Compares two or more slices for equality, as defined by predicate `pred`.
 
+See_also: $(SUBREF slice, .Slice.opEquals)
+
 Params:
     pred = The predicate.
 +/


### PR DESCRIPTION
Makes tweaks to the algorithm.d equal documentation to provide additional examples and See Also to Slice.opEqual.