### PR TITLE
Adjusting zip index

### DIFF
--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -2479,9 +2479,9 @@ auto zip
     foreach(i, S; Slices[1 .. $])
     {
         static assert(isSlice!S == packs, "zip: all Slices must have the same shape packs");
-        assert(slices[i]._lengths == slices[0]._lengths, "zip: all slices must have the same lengths");
+        assert(slices[i + 1]._lengths == slices[0]._lengths, "zip: all slices must have the same lengths");
         static if (sameStrides)
-            assert(slices[i].unpack.strides == slices[0].unpack.strides, "zip: all slices must have the same strides");
+            assert(slices[i + 1].unpack.strides == slices[0].unpack.strides, "zip: all slices must have the same strides");
     }
     static if (!sameStrides && minElem(staticMap!(kindOf, Slices)) != Contiguous)
     {


### PR DESCRIPTION
Fixing a bug in the way zip checks for lengths and strides.

The way it previously worked did not account for the fact that the foreach loop starts with `i=0`, but only goes through the length of `Slices[1 .. $].length`, so it will unnecessarily check `i=0` and miss the last data point. The fix bumps up `i` to `i+1`

See issue [59](https://github.com/libmir/mir-algorithm/issues/59)