### PR TITLE
Add chunks to package.d documentation

### DIFF
--- a/source/mir/ndslice/package.d
+++ b/source/mir/ndslice/package.d
@@ -251,6 +251,16 @@ $(TR $(TDNW $(SUBMODULE ndfield)
     )
 )
 
+$(TR $(TDNW $(SUBMODULE chunks)
+        $(BR) $(SMALL Declarations))
+     $(TD
+        $(SUBREF field, chunks)
+        $(SUBREF field, Chunks)
+        $(SUBREF field, isChunks)
+        $(SUBREF field, popFrontTuple)
+    )
+)
+
 ))
 
 $(H2 Example: Image Processing)


### PR DESCRIPTION
The chunks module was not listed on the ndslice documentation page.