### PR TITLE
Rename ContiguousTensor/CanonicalTensor/UniversalTensor

### DIFF
--- a/source/mir/ndslice/allocation.d
+++ b/source/mir/ndslice/allocation.d
@@ -48,7 +48,7 @@ Params:
 Returns:
     n-dimensional slice
 +/
-ContiguousTensor!(N, T)
+ContiguousSlice!(N, T)
     slice(T, size_t N)(size_t[N] lengths...)
 {
     immutable len = lengthsProduct(lengths);
@@ -56,7 +56,7 @@ ContiguousTensor!(N, T)
 }
 
 /// ditto
-ContiguousTensor!(N, T)
+ContiguousSlice!(N, T)
     slice(T, size_t N)(size_t[N] lengths, T init)
 {
     immutable len = lengthsProduct(lengths);
@@ -172,7 +172,7 @@ auto makeSlice(Allocator, size_t N, Iterator)(auto ref Allocator alloc, Slice!(N
 }
 
 /// ditto
-ContiguousTensor!(N, T)
+ContiguousSlice!(N, T)
 makeSlice(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths...)
 {
     import std.experimental.allocator : makeArray;
@@ -180,7 +180,7 @@ makeSlice(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths...
 }
 
 /// ditto
-ContiguousTensor!(N, T)
+ContiguousSlice!(N, T)
 makeSlice(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths, T init)
 {
     import std.experimental.allocator : makeArray;
@@ -190,7 +190,7 @@ makeSlice(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths, T
 }
 
 ///// ditto
-//ContiguousTensor!(N, T)
+//ContiguousSlice!(N, T)
 //makeSlice(T,
 //    Flag!`replaceArrayWithPointer` ra = Yes.replaceArrayWithPointer,
 //    Allocator,
@@ -257,7 +257,7 @@ Params:
 Returns:
     a structure with fields `array` and `slice`
 +/
-ContiguousTensor!(N, T)
+ContiguousSlice!(N, T)
 makeUninitSlice(T, Allocator, size_t N)(auto ref Allocator alloc, size_t[N] lengths...)
 {
     immutable len = lengthsProduct(lengths);

--- a/source/mir/ndslice/package.d
+++ b/source/mir/ndslice/package.d
@@ -459,8 +459,8 @@ unittest
 // relaxed example
 unittest
 {
-    static ContiguousTensor!(3, ubyte) movingWindowByChannel
-    (UniversalTensor!(3, ubyte) image, size_t nr, size_t nc, ubyte delegate(UniversalMatrix!ubyte) filter)
+    static ContiguousSlice!(3, ubyte) movingWindowByChannel
+    (UniversalSlice!(3, ubyte) image, size_t nr, size_t nc, ubyte delegate(UniversalMatrix!ubyte) filter)
     {
         return image
             .pack!1

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -124,11 +124,11 @@ alias CanonicalMatrix (T) = CanonicalTensor !(2, T);
 /// ditto
 alias UniversalMatrix (T) = UniversalTensor !(2, T);
 /// ditto
-alias ContiguousTensor(size_t dim, T) = Slice!(Contiguous, [dim], T*);
+alias ContiguousSlice (size_t dim, T) = Slice!(Contiguous, [dim], T*);
 /// ditto
-alias CanonicalTensor (size_t dim, T) = Slice!(Canonical , [dim], T*);
+alias CanonicalSlice (size_t dim, T) = Slice!(Canonical , [dim], T*);
 /// ditto
-alias UniversalTensor (size_t dim, T) = Slice!(Universal , [dim], T*);
+alias UniversalSlice (size_t dim, T) = Slice!(Universal , [dim], T*);
 
 /// Extracts $(LREF SliceKind).
 enum kindOf(T : Slice!(kind, packs, Iterator), SliceKind kind, size_t[] packs, Iterator) = kind;

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -129,6 +129,15 @@ alias ContiguousSlice (size_t dim, T) = Slice!(Contiguous, [dim], T*);
 alias CanonicalSlice (size_t dim, T) = Slice!(Canonical , [dim], T*);
 /// ditto
 alias UniversalSlice (size_t dim, T) = Slice!(Universal , [dim], T*);
+/// ditto
+deprecated("Please use ContiguousSlice") alias ContiguousTensor(size_t dim, T) = 
+    Slice!(Contiguous, [dim], T*);
+/// ditto
+deprecated("Please use CanonicalSlice") alias CanonicalTensor (size_t dim, T) = 
+    Slice!(Canonical , [dim], T*);
+/// ditto
+deprecated("Please use UniversalSlice") alias UniversalTensor (size_t dim, T) = 
+    Slice!(Universal , [dim], T*);
 
 /// Extracts $(LREF SliceKind).
 enum kindOf(T : Slice!(kind, packs, Iterator), SliceKind kind, size_t[] packs, Iterator) = kind;

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -114,15 +114,15 @@ Definition shortcuts for $(LREF Slice).
 
 See_also: $(LREF SliceKind).
 +/
-alias ContiguousVector(T) = ContiguousTensor!(1, T);
+alias ContiguousVector (T) = ContiguousSlice!(1, T);
 /// ditto
-alias UniversalVector (T) = UniversalTensor !(1, T);
+alias UniversalVector (T) = UniversalSlice!(1, T);
 /// ditto
-alias ContiguousMatrix(T) = ContiguousTensor!(2, T);
+alias ContiguousMatrix (T) = ContiguousSlice!(2, T);
 /// ditto
-alias CanonicalMatrix (T) = CanonicalTensor !(2, T);
+alias CanonicalMatrix (T) = CanonicalSlice!(2, T);
 /// ditto
-alias UniversalMatrix (T) = UniversalTensor !(2, T);
+alias UniversalMatrix (T) = UniversalSlice!(2, T);
 /// ditto
 alias ContiguousSlice (size_t dim, T) = Slice!(Contiguous, [dim], T*);
 /// ditto


### PR DESCRIPTION
Merging branch to rename ContiguousTensor, CanonicalTensor, and UniversalTensor to ContiguousSlice, CanonicalSlice, and UniversalSlice and adjust all other usage of the original terminology. 

This pull request intends to address issue [64](https://github.com/libmir/mir-algorithm/issues/64).