### PR TITLE
Add in packsOf alias for isSlice

### DIFF
--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -1470,7 +1470,7 @@ template count(alias fun)
         else
         {
             static if (isSlice!(Slices[0]))
-                enum flat = Slices.length == 1 && kindOf!(Slices[0]) == Contiguous && isSlice!(Slices[0]) != [1];
+                enum flat = Slices.length == 1 && kindOf!(Slices[0]) == Contiguous && packsOf!(Slices[0]) != [1];
             else
                 enum flat = false;
             static if (flat)

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -2118,7 +2118,7 @@ struct Slice(SliceKind kind, size_t[] packs, Iterator)
         {
             import mir.ndslice.topology : unpack;
             auto sl = this[slices].unpack;
-            static assert(isSlice!(typeof(sl))[0] == concatenation.N);
+            static assert(packsOf!(typeof(sl))[0] == concatenation.N);
             sl.opIndexOpAssignImplConcatenation!""(concatenation);
         }
 
@@ -2437,7 +2437,7 @@ struct Slice(SliceKind kind, size_t[] packs, Iterator)
         {
             import mir.ndslice.topology : unpack;
             auto sl = this[slices].unpack;
-            static assert(isSlice!(typeof(sl))[0] == concatenation.N);
+            static assert(packsOf!(typeof(sl))[0] == concatenation.N);
             sl.opIndexOpAssignImplConcatenation!op(concatenation);
         }
 

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -20,6 +20,7 @@ $(T2 sliced, Creates a slice on top of an iterator, a pointer, or an array's poi
 $(T2 slicedField, Creates a slice on top of a field, a random access range, or an array.)
 $(T2 slicedNdField, Creates a slice on top of an ndField.)
 $(T2 kindOf, Extracts $(LREF SliceKind).)
+$(T2 packsOf, Extracts dimension packs from a $(LREF Slice). Alias for $(LREF isSlice).)
 $(T2 isSlice, Extracts dimension packs from a type. Extracts `null` if the template argument is not a `Slice`.)
 $(T2 DeepElementType, Extracts the element type of a $(LREF Slice).)
 $(T2 Structure, A tuple of lengths and strides.)
@@ -147,6 +148,17 @@ enum kindOf(T : Slice!(kind, packs, Iterator), SliceKind kind, size_t[] packs, I
 unittest
 {
     static assert(kindOf!(Slice!(Universal, [1], int*)) == Universal);
+}
+
+/// Extracts dimension packs from a $(LREF Slice). Alias for $(LREF isSlice).
+alias packsOf(T) = isSlice!(T);
+
+@safe pure nothrow @nogc
+unittest
+{
+    alias S = Slice!(Universal, [2, 3], int*);
+
+    static assert(packsOf!S == [2, 3]);
 }
 
 private template SkipDimension(size_t dimension, size_t index)

--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -2475,10 +2475,10 @@ auto zip
     (bool sameStrides = false, Slices...)(Slices slices)
     if (Slices.length > 1 && allSatisfy!(isSlice, Slices))
 {
-    enum packs = isSlice!(Slices[0]);
+    enum packs = packsOf!(Slices[0]);
     foreach(i, S; Slices[1 .. $])
     {
-        static assert(isSlice!S == packs, "zip: all Slices must have the same shape packs");
+        static assert(packsOf!S == packs, "zip: all Slices must have the same shape packs");
         assert(slices[i + 1]._lengths == slices[0]._lengths, "zip: all slices must have the same lengths");
         static if (sameStrides)
             assert(slices[i + 1].unpack.strides == slices[0].unpack.strides, "zip: all slices must have the same strides");


### PR DESCRIPTION
This pull request addresses issue #66 that I created.

The `isSlice` function currently performs double-duty, also returning packs information. This change adds in an alias `packsOf` for isSlice. Other adjustments change the behavior where isSlice is currently used.

Update of previous PR #68 (had deleted to clean up my fork, b/c I am git idiot).