### PR TITLE
Add traits to doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -49,6 +49,7 @@ PACKAGE_mir_ndslice = \
 	slice\
 	sorting\
 	topology\
+	traits\
 
 MOD_EXCLUDES=$(addprefix --ex=,)
 


### PR DESCRIPTION
After adding the traits module to ndslice, it was not showing up properly in the docs. I believe adding traits to the doc Makefile will resolve the issue.