### PR TITLE
Add math/package.d

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -32,7 +32,7 @@ PACKAGE_mir = bitmanip conv functional primitives timeseries utility
 PACKAGE_mir_array = primitives
 PACKAGE_mir_internal = utility
 PACKAGE_mir_interpolation = package linear pchip
-PACKAGE_mir_math = constant common sum numeric
+PACKAGE_mir_math = constant common sum numeric package
 PACKAGE_mir_math_func = expdigamma
 
 PACKAGE_mir_ndslice = \

--- a/index.d
+++ b/index.d
@@ -27,6 +27,7 @@ $(BOOKTABLE ,
     $(LEADINGROW Finance)
     $(TR $(TDNW $(MREF mir,timeseries)) $(TD Time-series))
     $(LEADINGROW Math)
+    $(TR $(TDNW $(MREF mir,math)) $(TD Package))
     $(TR $(TDNW $(MREF mir,math,common)) $(TD Common math functions))
     $(TR $(TDNW $(MREF mir,math,constant)) $(TD Constants))
     $(LEADINGROW Numeric)

--- a/source/mir/math/package.d
+++ b/source/mir/math/package.d
@@ -1,0 +1,22 @@
+/++
+$(H1 Math Functionality)
+$(BOOKTABLE $(H2 ,Math modules),
+$(TR $(TH Module) $(TH Math kind))
+$(T2M common, Common math functions)
+$(T2M constant, Constants)
+$(T2M sum, Various precise summation algorithms)
+$(T2M numeric, Simple numeric algorithms)
+)
+Copyright: Copyright © 2017, Kaleidic Associates Advisory Limited
+Authors:   Ilya Yaroshenko
+Macros:
+SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, math, $1)$(NBSP)
+T2M=$(TR $(TDNW $(MREF mir,math,$1)) $(TD $+))
+T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
++/
+module mir.math;
+
+public import mir.math.common;
+public import mir.math.constant;
+public import mir.math.sum;
+public import mir.math.numeric;


### PR DESCRIPTION
There is currently no package.d file for mir.math. This pull request adds this file and relevant documentation and functionality (public imports of the relevant submodules of mir.math).

Where a user previously had to write
`import mir.math.sum : sum`
a user now should be able to write
`import mir.math : sum`