### PR TITLE
Add exes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 *.pdf
 *.s
+*.exe
 *.sublime-project
 *.sublime-workspace
 .dub
@@ -12,6 +13,8 @@
 __*
 dub.selections.json
 mir-algorithm
+mir-algorithm.exe
 mir-algorithm-test-library
+mir-algorithm-test-library.exe
 mir-internal
 web

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@
 __*
 dub.selections.json
 mir-algorithm
-mir-algorithm.exe
 mir-algorithm-test-library
-mir-algorithm-test-library.exe
 mir-internal
 web


### PR DESCRIPTION
The .gitignore file as currently set up does not take into account Windows development. Testing on Windows generates exe's that must be removed before commiting. 