### PR TITLE
Fix unittest/compilation failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - {os: linux, d: ldc, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: dmd-beta, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: dmd, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+  allow_failures:
+    - {d: dmd-nightly}
 branches:
   only:
     - master

--- a/source/mir/interpolate/package.d
+++ b/source/mir/interpolate/package.d
@@ -229,7 +229,7 @@ version(LDC)
 else
     enum LDC = false;
 
-version(x86_64)
+version(X86_64)
     enum x86_64 = true;
 else
     enum x86_64 = false;
@@ -562,15 +562,17 @@ auto vectorize(Kernel, F, size_t N, size_t R)(ref Kernel kernel, ref F[N] a, ref
     }
     else
     {
+        F[N][R] _c = void;//Temporary array in case "c" overlaps "a" and/or "b".
         foreach(i; Iota!N)
         {
             auto r = kernel(a[i], b[i]);
             static if (R == 1)
-                return c[0] = r;
+                _c[0][i] = r;
             else
                 foreach(j; Iota!R)
-                    c[j][i] = r[j];
+                    _c[j][i] = r[j];
         }
+        c = _c;
     }
 }
 

--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -1449,10 +1449,17 @@ Slice!(Contiguous, [1], StrideIterator!(SliceIterator!(packs[1 .. $].sum == 1 &&
     size_t[Ret.N] lengths;
     sizediff_t[Ret.S] strides;
     lengths[0] = slice._lengths[0];
-    return Ret(lengths, strides, typeof(Ret._iterator)(slice._strides[0], typeof(Ret._iterator._iterator)(
+    enum ret_mixin = q{
+        Ret(lengths, strides, typeof(Ret._iterator)(slice._strides[0], typeof(Ret._iterator._iterator)(
         slice._lengths[1 .. Ret._iterator._iterator.Elem.N + 1],
         slice._strides[1 .. Ret._iterator._iterator.Elem.S + 1],
         slice._iterator)));
+    };
+    version (LDC_LLVM_400)
+        //Workaround to allow compilation with LDC 1.2.0.
+        mixin ("Ret ret = "~ret_mixin~" return ret;");
+    else
+        mixin ("return "~ret_mixin);
 }
 
 version(mir_test) unittest


### PR DESCRIPTION
The problem seems to be that in the non-vector fallback path of mir.interpolate.vectorize, input was being overwritten by output. Also x64 wasn't being detected. Please review the "R == 1" case where I made a change that I believe is correct but might be wrong.

~~This pull request doesn't fix the "escaping reference to local variable slice" errors in mir.ndslice.topology.d when compiling with ldc-1.2.0.~~

**EDIT:** Also added workaround for error in "tensor mutation on-the-fly" unittest with DMD x86-64 on non-Windows platforms. Also added workaround to allow compilation with ldc-1.2.0. 