### PR TITLE
Spelling fixes

### DIFF
--- a/source/mir/array/primitives.d
+++ b/source/mir/array/primitives.d
@@ -3,7 +3,7 @@ Range primitives for arrays with multi-dimensional like API support.
 
 Note:
 UTF strings behaves like common arrays in Mir.
-`std.uni.byCodePoint` can be used to creat a range of chararacters.
+`std.uni.byCodePoint` can be used to create a range of characters.
 
 See_also: $(MREF mir,_primitives).
 

--- a/source/mir/functional.d
+++ b/source/mir/functional.d
@@ -119,9 +119,9 @@ alias tuple = refTuple;
 /++
 Returns: a $(LREF RefTuple) structure.
 
-If an argument is accessable by reference, then its pointer is stored instead.
+If an argument is accessible by reference, then its pointer is stored instead.
 
-Use refTuple in combintation with $(LREF unref) to make a completely value tuple.
+Use refTuple in combination with $(LREF unref) to make a completely value tuple.
 +/
 RefTuple!Args refTuple(Args...)(auto ref Args args)
 {
@@ -345,7 +345,7 @@ version(mir_test) unittest
     assert(&naryFun!("a")(a) == &a);
 }
 
-/// `args` paramter tuple
+/// `args` parameter tuple
 version(mir_test) unittest
 {
     assert(naryFun!("args[0] + args[1]")(2, 3) == 5);
@@ -748,10 +748,10 @@ template aliasCall(string methodName, TemplateArgs...)
     S s;
 
     auto sfun = aliasCall!"fun"(s);
-    assert(3.iota.vmap(sfun) == io + 1);   //  opCall is overloded
-    assert(3.iota.map!sfun == io + 1);  //  opCall is overloded
+    assert(3.iota.vmap(sfun) == io + 1);   //  opCall is overloaded
+    assert(3.iota.map!sfun == io + 1);  //  opCall is overloaded
 
     auto sfun10 = aliasCall!("fun", 10)(s);   // uses fun!10
-    assert(3.iota.vmap(sfun10) == io + 10);   //  opCall is overloded
-    assert(3.iota.map!sfun10 == io + 10);   //  opCall is overloded
+    assert(3.iota.vmap(sfun10) == io + 10);   //  opCall is overloaded
+    assert(3.iota.map!sfun10 == io + 10);   //  opCall is overloaded
 }

--- a/source/mir/internal/memory.d
+++ b/source/mir/internal/memory.d
@@ -81,7 +81,7 @@ version (Windows)
 
             if (!ptr) return _aligned_malloc(size, alignment);
 
-            // gets the header from the exising pointer
+            // gets the header from the existing pointer
             AlignInfo!()* head = AlignInfo!()(ptr);
 
             // gets a new aligned pointer
@@ -93,7 +93,7 @@ version (Windows)
                 return null;
             }
 
-            // copy exising data
+            // copy existing data
             memcpy(alignedPtr, ptr, head.size);
             free(head.basePtr);
 

--- a/source/mir/interpolate/constant.d
+++ b/source/mir/interpolate/constant.d
@@ -62,7 +62,7 @@ Returns: $(LREF Constant)
 template constant(T, size_t N = 1, FirstGridIterator = immutable(T)*, NextGridIterators = Repeat!(N - 1, FirstGridIterator))
     if (is(T == Unqual!T) && N <= 6)
 {
-    static if (N > 1) pragma(msg, "Warning: multivariate constant interplant was not tested.");
+    static if (N > 1) pragma(msg, "Warning: multivariate constant interpolant was not tested.");
 
     private alias GridIterators = AliasSeq!(FirstGridIterator, NextGridIterators);
     private alias GridVectors = Constant!(T, N, GridIterators).GridVectors;

--- a/source/mir/interpolate/linear.d
+++ b/source/mir/interpolate/linear.d
@@ -91,7 +91,7 @@ version(mir_test)
     assert(approxEqual(xs.sliced.map!interpolation, data, 1e-4, 1e-4));
 }
 
-/// R^2 -> R: Bilinear interpolaiton
+/// R^2 -> R: Bilinear interpolation
 version(mir_test)
 @safe pure unittest
 {
@@ -133,7 +133,7 @@ version(mir_test)
     assert(appreq(d[1][1], y_x0x1));
 }
 
-/// R^3 -> R: Trilinear interpolaiton
+/// R^3 -> R: Trilinear interpolation
 version(mir_test)
 @safe pure unittest
 {

--- a/source/mir/interpolate/spline.d
+++ b/source/mir/interpolate/spline.d
@@ -198,7 +198,7 @@ version(mir_test)
     assert(approxEqual(xs.sliced.vmap(interpolation), data, 1e-4, 1e-4));
 }
 
-/// R^2 -> R: Bicubic interpolaiton
+/// R^2 -> R: Bicubic interpolation
 version(mir_test)
 unittest
 {
@@ -252,7 +252,7 @@ unittest
     // assert(appreq(d[1][1], y_x0x1));
 }
 
-/// R^3 -> R: Tricubic interpolaiton
+/// R^3 -> R: Tricubic interpolation
 version(mir_test)
 unittest
 {
@@ -336,8 +336,8 @@ template spline(T, size_t N = 1, FirstGridIterator = immutable(T)*, NextGridIter
     Params:
         grid = immutable `x` values for interpolant
         values = `f(x)` values for interpolant
-        typeOfBondaries = $(LREF SplineBoundaryType) for both tails (optional).
-        valueOfBondaryConditions = value of the boundary type (optional). 
+        typeOfBoundaries = $(LREF SplineBoundaryType) for both tails (optional).
+        valueOfBoundaryConditions = value of the boundary type (optional). 
     Constraints:
         `grid` and `values` must have the same length >= 3
     Returns: $(LREF Spline)
@@ -345,18 +345,18 @@ template spline(T, size_t N = 1, FirstGridIterator = immutable(T)*, NextGridIter
     Spline!(T, N, GridIterators) spline(SliceKind ykind, yIterator)(
         GridVectors grid,
         scope Slice!(ykind, [N], yIterator) values,
-        SplineBoundaryType typeOfBondaries = SplineBoundaryType.notAKnot,
-        in T valueOfBondaryConditions = 0,
+        SplineBoundaryType typeOfBoundaries = SplineBoundaryType.notAKnot,
+        in T valueOfBoundaryConditions = 0,
         )
     {
-        return spline(grid, values, SplineBoundaryCondition!T(typeOfBondaries, valueOfBondaryConditions));
+        return spline(grid, values, SplineBoundaryCondition!T(typeOfBoundaries, valueOfBoundaryConditions));
     }
 
     /++
     Params:
         grid = immutable `x` values for interpolant
         values = `f(x)` values for interpolant
-        bondaries = $(LREF SplineBoundaryCondition) for both tails.
+        boundaries = $(LREF SplineBoundaryCondition) for both tails.
     Constraints:
         `grid` and `values` must have the same length >= 3
     Returns: $(LREF Spline)
@@ -364,10 +364,10 @@ template spline(T, size_t N = 1, FirstGridIterator = immutable(T)*, NextGridIter
     Spline!(T, N, GridIterators) spline(SliceKind ykind, yIterator)(
         GridVectors grid,
         scope Slice!(ykind, [N], yIterator) values,
-        SplineBoundaryCondition!T bondaries,
+        SplineBoundaryCondition!T boundaries,
         )
     {
-        return spline(grid, values, bondaries, bondaries);
+        return spline(grid, values, boundaries, boundaries);
     }
 
     /++
@@ -486,7 +486,7 @@ struct Spline(F, size_t N = 1, FirstGridIterator = immutable(F)*, NextGridIterat
             assert(x.length >= 2, "cubic spline interpolant: minimal allowed length for the grid equals 2.");
             shape[i] = x.length;
             // assert(x.length == values.length!i, "grid[" ~ i.stringof ~
-            //     "].length shoud be equal to values.length!" ~ i.stringof ~ ".");
+            //     "].length should be equal to values.length!" ~ i.stringof ~ ".");
         }
 
         auto data_ptr = cast(F[2 ^^ N]*) (alignedAllocate(F[2 ^^ N].sizeof * shape.iota.elementsCount + alignment, alignment) + alignment);
@@ -522,7 +522,7 @@ struct Spline(F, size_t N = 1, FirstGridIterator = immutable(F)*, NextGridIterat
 
     /++
     Computes derivatives and stores them in `_data`.
-    `_data` is assumeed to be preinitialized with function values filled in `F[2 ^^ N][0]`.
+    `_data` is assumed to be preinitialized with function values filled in `F[2 ^^ N][0]`.
     Params:
         lbc = left boundary condition
         rbc = right boundary condition

--- a/source/mir/math/common.d
+++ b/source/mir/math/common.d
@@ -1,7 +1,7 @@
 /++
 Common floating point math functions.
 
-This module has generic LLVM-oriented API compatable with all D compilers.
+This module has generic LLVM-oriented API compatible with all D compilers.
 
 License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Copyright: Copyright © 2016-, Ilya Yaroshenko
@@ -32,7 +32,7 @@ version(LDC)
     It is similar to $(LREF fastmath), but does not allow unsafe-fp-math.
     This flag does NOT force LDC to use the reciprocal of an argument rather than perform division.
 
-    This flag is defualt for string lambdas.
+    This flag is default for string lambdas.
 
     Note: Can be used with all compilers.
     +/

--- a/source/mir/math/numeric.d
+++ b/source/mir/math/numeric.d
@@ -1,5 +1,5 @@
 /++
-This module contains simple numric algorithms.
+This module contains simple numeric algorithms.
 
 License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
 
@@ -50,7 +50,7 @@ struct Prod(T)
 }
 
 /++
-Compute the product of the input range $(D r) using separate exponent accomulation.
+Compute the product of the input range $(D r) using separate exponent accumulation.
 +/
 Unqual!(ForeachType!Range) prod(Range)(Range r, ref long exp)
 	if (isFloatingPoint!(ForeachType!Range))

--- a/source/mir/ndslice/concatenation.d
+++ b/source/mir/ndslice/concatenation.d
@@ -50,7 +50,7 @@ private template _expose(size_t maxN, size_t dim)
         }
         else
         {
-            static assert(s.shape.length == s.N, "Cannot create concatentaion for packed slice of smaller dimension.");
+            static assert(s.shape.length == s.N, "Cannot create concatenation for packed slice of smaller dimension.");
             import mir.ndslice.topology: repeat, unpack;
             auto r = s.repeat(1).unpack;
             static if (dim)

--- a/source/mir/ndslice/connect/cpython.d
+++ b/source/mir/ndslice/connect/cpython.d
@@ -20,7 +20,7 @@ import std.traits;
 
 /++
 Construct flags for $(PGB).
-If `T` is not `const` or `immutable` then the flags requrie writable buffer.
+If `T` is not `const` or `immutable` then the flags require writable buffer.
 If slice kind is $(SUBREF slice, Contiguous) then the flags require $(LINK2 https://docs.python.org/3/c-api/buffer.html#contiguity-requests, c_contiguous) buffer.
 
 Params:
@@ -95,7 +95,7 @@ Params:
     view = output $(LREF Py_buffer).
         $(LREF Py_buffer.internal) is initialized with null value,
         $(LREF Py_buffer.obj) is not initialized.
-        Other $(LREF Py_buffer) fields are initialized accroding to the flags and slice.
+        Other $(LREF Py_buffer) fields are initialized according to the flags and slice.
     flags = requester flags
     structureBuffer = Single chunk of memory with the same alignment and size as $(SUBREF _slice, Structure).
         The buffer is used to store shape and strides for the view.

--- a/source/mir/ndslice/dynamic.d
+++ b/source/mir/ndslice/dynamic.d
@@ -36,7 +36,7 @@ $(TR $(TH Function Name) $(TH Description))
 $(T2 rotated, Rotates two selected dimensions by `k*90` degrees. $(BR)
     `iota(2, 3).rotated` equals to `[[2, 5], [1, 4], [0, 3]]`.)
 $(T2 dropToHypercube, Returns maximal multidimensional cube of a slice.)
-$(T2 normalizeStructure, Reverses iteration order for dimensions with nagative strides, they become not negative;
+$(T2 normalizeStructure, Reverses iteration order for dimensions with negative strides, they become not negative;
 and sorts dimensions according to the strides, dimensions with larger strides are going first.)
 )
 
@@ -90,7 +90,7 @@ import mir.utility;
 @optmath:
 
 /++
-Reverses iteration order for dimensions with nagative strides, they become not negative;
+Reverses iteration order for dimensions with negative strides, they become not negative;
 and sorts dimensions according to the strides, dimensions with larger strides are going first.
 
 Params:

--- a/source/mir/ndslice/field.d
+++ b/source/mir/ndslice/field.d
@@ -78,10 +78,13 @@ struct MapField(Field, alias fun)
         return _field.shape;
     }
 
-    auto elemenstCount()() @property
+    auto elementsCount()() @property
     {
-        return _field.elemenstCount;
+        return _field.elementsCount;
     }
+
+    deprecated("this is a misspelling of 'elementsCount'")
+    alias elemenstCount() = elementsCount!();
 }
 
 /++

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -765,7 +765,7 @@ struct Slice(SliceKind kind, size_t[] packs, Iterator)
         private alias ImmutableThis = Slice!(kind, packs, immutable(Unqual!(PointerTarget!Iterator))*);
 
         /++
-        Cast to const and immutable slices in case of underlaying range is a pointer.
+        Cast to const and immutable slices in case of underlying range is a pointer.
         +/
         ref toImmutable()() immutable @trusted pure nothrow @nogc
         {
@@ -2051,7 +2051,7 @@ struct Slice(SliceKind kind, size_t[] packs, Iterator)
     Returns:
         lazy slice the same shape that has $(LREF Contiguous) kind
     Note:
-        Binary operator overloading is allowed if both slices are contigous or one-dimensional.
+        Binary operator overloading is allowed if both slices are contiguous or one-dimensional.
         $(BR)
         Does not allocate neither new slice nor a closure.
     +/

--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -1500,7 +1500,7 @@ version(mir_test) unittest
 
     elems.popFrontExactly(2);
     assert(elems.front == 2);
-    /// `_index` is availble only for canonical and universal ndslices.
+    /// `_index` is available only for canonical and universal ndslices.
     assert(elems._iterator._indexes == [0, 2]);
 
     elems.popBackExactly(2);
@@ -2142,7 +2142,7 @@ version(mir_test) unittest
 /++
 Bytegroup slice over an integral slice.
 
-Groups exisinting slice into fixed length chunks and uses them as data store for destination type.
+Groups existing slice into fixed length chunks and uses them as data store for destination type.
 
 Correctly handles scalar types on both little-endian and big-endian platforms.
 
@@ -2831,7 +2831,7 @@ Pairwise map for vectors.
 Works with packed slices.
 
 Params:
-    fun = function to accomulate
+    fun = function to accumulate
     lag = an integer indicating which lag to use
 Returns: lazy ndslice composed of `fun(a_n, a_n+1)` values.
 

--- a/source/mir/utility.d
+++ b/source/mir/utility.d
@@ -596,7 +596,7 @@ unittest
     immutable a = 0x93_8d_28_00_0f_50_a5_56;
     immutable b = 0x54_c3_2f_e8_cc_a5_97_10;
     enum c = extMul(a, b);     // Compile time algorithm
-    assert(extMul(a, b) == c); // Fast runtime algorihtm
+    assert(extMul(a, b) == c); // Fast runtime algorithm
     static assert(c.high == 0x30_da_d1_42_95_4a_50_78);
     static assert(c.low == 0x27_9b_4b_b4_9e_fe_0f_60);
 }


### PR DESCRIPTION
All changes were documentation or variable names except for `MapField.elemenstCount`.
Corrected the spelling there but left a deprecated alias in case anyone was using the
old version. (Unfortunately the compiler doesn't emit a warning when using a deprecated
alias.)