### PR TITLE
Make all examples at the docs runnable like on dlang.org

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -107,15 +107,19 @@ $(DOC_OUTPUT_DIR)/$(call D2HTML,$p) : $(call ADDSOURCE,$p) $(STDDOC) ;\
 IMAGES=images/mir.svg favicon.ico
 
 JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
-	dlang ddox listanchors run run-main-website jquery-1.7.2.min))
+	codemirror-compressed dlang ddox listanchors run run_examples jquery-1.7.2.min))
 
 STYLES=$(addsuffix .css, $(addprefix css/, \
-	style print custom ))
+	style print custom codemirror))
 
 ALL_FILES = $(addprefix $(DOC_OUTPUT_DIR)/, \
 	$(STYLES) $(IMAGES) $(JAVASCRIPT))
 
 $(DOC_OUTPUT_DIR)/css/custom.css: $(DOC_SOURCE_DIR)/custom.css
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+$(DOC_OUTPUT_DIR)/js/run_examples.js: $(DOC_SOURCE_DIR)/run_examples_custom.js
 	@mkdir -p $(dir $@)
 	cp $< $@
 

--- a/doc/custom.ddoc
+++ b/doc/custom.ddoc
@@ -45,6 +45,7 @@ $(COMMON_HEADERS_DLANG)
 <link rel="stylesheet" href="$(STATIC css/style.css)">
 <link rel="stylesheet" href="$(STATIC css/custom.css)">
 <link rel="stylesheet" href="$(STATIC css/print.css)" media="print">
+<link rel="stylesheet" href="$(STATIC css/codemirror.css)">
 <link rel="shortcut icon" href="$(FAVICON)">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.1, maximum-scale=10.0">
 $(EXTRA_HEADERS)
@@ -119,7 +120,9 @@ COMMON_SCRIPTS =
     $(COMMON_SCRIPTS_DLANG)
 _=
 COMMON_SCRIPTS_DLANG =
+    $(SCRIPTLOAD $(STATIC js/codemirror-compressed.js))
     $(SCRIPTLOAD $(STATIC js/run.js))
+    $(SCRIPTLOAD $(STATIC js/run_examples.js))
 _=
 
 COMMON_HEADERS_DLANG=

--- a/doc/run_examples_custom.js
+++ b/doc/run_examples_custom.js
@@ -1,0 +1,90 @@
+/**
+ * Run all unittest examples
+ *
+ * Copyright 2016 by D Language Foundation
+ *
+ * License: http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+ */
+
+// wraps a unittest into a runnable script
+function wrapIntoMain(code) {
+    var currentPackage = $('body')[0].id;
+    // BUMP mir-algorithm image here: https://github.com/dlang-tour/core-exec/blob/master/Dockerfile
+    // run.dlang.io frontend: https://github.com/dlang-tour/core/blob/master/public/static/js/tour-controller.js#L398
+    var codeOut = '/+dub.sdl:\ndependency "mir-algorithm" version="~>0.6.14"\n+/\n';
+
+    // dynamically wrap into main if needed
+    if (code.indexOf("void main") >= 0) {
+        codeOut += "import " + currentPackage + "; ";
+        codeOut += code;
+    }
+    else {
+        codeOut += "void main()\n{\n";
+        codeOut += "    import " + currentPackage + ";\n";
+        // writing to the stdout is probably often used
+        codeOut += "    import std.stdio: write, writeln, writef, writefln;\n    ";
+        codeOut += code.split("\n").join("\n    ");
+        codeOut += "\n}";
+    }
+    return codeOut;
+}
+
+$(document).ready(function()
+{
+    if ($('body')[0].id == "Home")
+        return;
+
+    // only for std at the moment
+    if (!$('body').hasClass("std"))
+        return;
+
+    // first selector is for ddoc - second for ddox
+    var codeBlocks = $('pre[class~=d_code]').add('pre[class~=code]');
+    codeBlocks.each(function(index)
+    {
+        var currentExample = $(this);
+        var orig = currentExample.html();
+
+        // check whether it is from a ddoced unittest
+        // 1) check is for ddoc, 2) for ddox
+        // manual created tests most likely can't be run without modifications
+        if (!($(this).parent().parent().prev().hasClass("dlang_runnable") ||
+              $(this).prev().children(":last").hasClass("dlang_runnable")))
+            return;
+
+        currentExample.replaceWith(
+                '<div class="unittest_examples">'
+                    + '<div class="d_code">'
+                        + '<pre class="d_code">'+orig+'</pre>'
+                    + '</div>'
+                    + '<div class="d_run_code" style="display: block">'
+                        + '<textarea class="d_code" style="display: none;"></textarea>'
+                    + '</div>'
+                    + '<div class="d_example_buttons">'
+          + '<div class="editButton"><i class="fa fa-edit" aria-hidden="true"></i> Edit</div>'
+          + '<div class="runButton"><i class="fa fa-play" aria-hidden="true"></i> Run</div>'
+          + '<div class="resetButton" style="display:none"><i class="fa fa-undo " aria-hidden="true"></i> Reset</div>'
+          + '<div class="openInEditorButton" title="Open in an external editor"><i class="fa fa-external-link" aria-hidden="true"></i></div>'
+                    + '</div>'
+                    + '<div class="d_code_output"><span class="d_code_title">Application output</span><br><pre class="d_code_output" readonly>Running...</pre>'
+                + '</div>'
+        );
+    });
+
+    $('textarea[class=d_code]').each(function(index) {
+        var parent = $(this).parent();
+        var btnParent = parent.parent().children(".d_example_buttons");
+        var outputDiv = parent.parent().children(".d_code_output");
+        var editor = setupTextarea(this,  {
+          parent: btnParent,
+          outputDiv: outputDiv,
+          stdin: false,
+          args: false,
+          transformOutput: wrapIntoMain,
+          defaultOutput: "All tests passed",
+          keepCode: true,
+          outputHeight: "auto",
+          backend: "tour"
+        });
+    });
+});


### PR DESCRIPTION
Make all examples at the docs runnable like on dlang.org

Now that I overhauled [run.dlang.io](https://run.dlang.io) this is got pretty easy.

Note:
- that I copied the `run_example.js` over from the dlang.org repo to make updates in the future easier.
- the assert->writeln pipeline isn't run here (it's a PITA to do with Make)

Preview: http://files.wilzbach.me/dlang/mir-algorithm/mir_ndslice_algorithm.html

See also: upcoming Mir series here https://tour.dlang.org/tour/en/dub/mir (anyone can help to fill the blanks - the backend is there)