### PR TITLE
Runnable examples: automatically inject the latest version

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 ###########################################################
 
 # tags
-LATEST:=$(git describe --abbrev=0 --tags | tr -d v)
+LATEST:=$(shell git describe --abbrev=0 --tags | tr -d v)
 
 # binaries
 DMD=dmd

--- a/doc/custom.ddoc
+++ b/doc/custom.ddoc
@@ -51,7 +51,9 @@ $(COMMON_HEADERS_DLANG)
 $(EXTRA_HEADERS)
 </head>
 <body id='$(TITLE)' class='$(BODYCLASS)'>
-$(SCRIPT document.body.className += ' have-javascript')
+$(SCRIPT document.body.className += ' have-javascript';
+var currentVersion = "$(LATEST)";
+)
 $(DIVID top, $(DIVC helper, $(DIVC helper expand-container,
     <a href="$(ROOT_DIR)menu.html" title="Menu" class="hamburger expand-toggle"><span>Menu</span></a>
     $(NAVIGATION)

--- a/doc/run_examples_custom.js
+++ b/doc/run_examples_custom.js
@@ -11,7 +11,7 @@ function wrapIntoMain(code) {
     var currentPackage = $('body')[0].id;
     // BUMP mir-algorithm image here: https://github.com/dlang-tour/core-exec/blob/master/Dockerfile
     // run.dlang.io frontend: https://github.com/dlang-tour/core/blob/master/public/static/js/tour-controller.js#L398
-    var codeOut = '/+dub.sdl:\ndependency "mir-algorithm" version="~>0.6.14"\n+/\n';
+    var codeOut = '/+dub.sdl:\ndependency "mir-algorithm" version="~>'+currentVersion+'"\n+/\n';
 
     // dynamically wrap into main if needed
     if (code.indexOf("void main") >= 0) {


### PR DESCRIPTION
When people click on open on run.dlang.io, currently a hard-coded version will be inserted.
This PR will remove the need for hard-coding this. However, at run.dlang.io, we only fetch the latest released version (the backend will automagically patch the `dub.sdl`), so when people request `~>0.8.0-alpha.4`, they would get `0.7.0`.
I might change it later, so that both the latest released and latest pre-release version are cached.