### PR TITLE
Use latest stable version for run.dlang.io for now

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -66,6 +66,7 @@ STDDOC=$(addsuffix .ddoc, ${DLANGORG_MACROS} ${GENERATED}/${LATEST} $(DLANGORG_D
 ${GENERATED}/${LATEST}.ddoc :
 	mkdir -p $(dir $@)
 	echo "LATEST=${LATEST}" >$@
+	echo "LATEST_STABLE=$(shell git tag | grep -vE "(alpha|beta)" | tail -n1 | tr -d v)" >> $@
 
 ${GENERATED}/mir.ddoc : $(DOC_SOURCE_DIR)/gen_modlist.d $(ALGORITHM_DIR)
 	mkdir -p $(dir $@)

--- a/doc/custom.ddoc
+++ b/doc/custom.ddoc
@@ -52,7 +52,7 @@ $(EXTRA_HEADERS)
 </head>
 <body id='$(TITLE)' class='$(BODYCLASS)'>
 $(SCRIPT document.body.className += ' have-javascript';
-var currentVersion = "$(LATEST)";
+var currentVersion = "$(LATEST_STABLE)";
 )
 $(DIVID top, $(DIVC helper, $(DIVC helper expand-container,
     <a href="$(ROOT_DIR)menu.html" title="Menu" class="hamburger expand-toggle"><span>Menu</span></a>


### PR DESCRIPTION
For now, run.dlang.io only contains the latest stable release.
This will make sure, that this is selected.
I might build the latest unstable release too over the next days, but not today anymore.