### PR TITLE
eachLower/Upper: make k immutable

### DIFF
--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -2159,7 +2159,7 @@ template eachLower(alias fun)
 
             static if ((Inputs.length > 1) && (isIntegral!(Inputs[$ - 1])))
             {
-                sizediff_t k = inputs[$ - 1];
+                immutable(sizediff_t) k = inputs[$ - 1];
                 alias Slices = Inputs[0..($ - 1)];
                 alias slices = inputs[0..($ - 1)];
             }
@@ -2623,7 +2623,7 @@ template eachUpper(alias fun)
 
             static if ((Inputs.length > 1) && (isIntegral!(Inputs[$ - 1])))
             {
-                sizediff_t k = inputs[$ - 1];
+                immutable(sizediff_t) k = inputs[$ - 1];
                 alias Slices = Inputs[0..($ - 1)];
                 alias slices = inputs[0..($ - 1)];
             }


### PR DESCRIPTION
enum doesn't work here because it's a run-time variable, but should be able to make it immutable. dmd crashes when I run dub test, but I think it's unrelated.