### PR TITLE
Start fixing public test imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ web
 docs
 *.html
 docs.json
+out/
+/tests_extractor.d

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ branches:
     - master
 script:
  - travis_wait 100 dub test --arch "$ARCH"
+ - ./test_examples.sh
  - travis_wait 100 dub test --arch "$ARCH" --build=unittest-cov
  - travis_wait 100 dub test --arch "$ARCH" --build=unittest-release
- - test_examples.sh
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ script:
  - travis_wait 100 dub test --arch "$ARCH"
  - travis_wait 100 dub test --arch "$ARCH" --build=unittest-cov
  - travis_wait 100 dub test --arch "$ARCH" --build=unittest-release
+ - test_examples.sh
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -45,6 +45,7 @@ unittest
 version(mir_test)
 unittest
 {
+    import std.traits : isFloatingPoint;
     static struct Quaternion(F)
         if (isFloatingPoint!F)
     {
@@ -250,6 +251,7 @@ version(mir_test)
 unittest
 {
     import core.simd;
+    import std.meta : AliasSeq;
     double2 a = 1, b = 2, c = 3, d = 6;
     with(Summation)
     {

--- a/source/mir/ndslice/concatenation.d
+++ b/source/mir/ndslice/concatenation.d
@@ -140,6 +140,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: iota;
+    import mir.ndslice.slice : slicedNdField;
 
     // 0, 1, 2
     // 3, 4, 5
@@ -187,6 +188,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: iota;
+    import mir.ndslice.slice : slicedNdField;
 
     size_t i;
     auto a = 3.iota;

--- a/source/mir/ndslice/connect/cpython.d
+++ b/source/mir/ndslice/connect/cpython.d
@@ -77,6 +77,7 @@ PythonBufferErrorCode fromPythonBuffer(SliceKind kind, size_t[] packs, T)(ref Sl
 ///
 unittest
 {
+    import mir.ndslice.slice : ContiguousMatrix;
     auto bar(ref const Py_buffer view)
     {
         ContiguousMatrix!(const double) mat = void;
@@ -211,10 +212,11 @@ PythonBufferErrorCode toPythonBuffer(SliceKind kind, size_t[] packs, T, size_t N
 ///
 unittest
 {
+    import mir.ndslice.slice : Slice, Structure, Universal;
     Py_buffer bar(Slice!(Universal, [2], double*) slice)
     {
         import core.stdc.stdlib;
-        enum N = slice.N;
+        enum N = 2;
 
         auto structurePtr = cast(Structure!N*) Structure!N.sizeof.malloc;
         if (!structurePtr)

--- a/source/mir/ndslice/fuse.d
+++ b/source/mir/ndslice/fuse.d
@@ -104,6 +104,7 @@ unittest
 {
     import mir.ndslice.fuse;
     import mir.ndslice.topology: iota;
+    import mir.ndslice.slice : Contiguous, Slice;
 
     enum ror = [
             [0, 1, 2, 3],
@@ -127,6 +128,7 @@ unittest
     import mir.ndslice.fuse;
     import mir.ndslice.topology: iota;
     import mir.ndslice.dynamic: transposed;
+    import mir.ndslice.slice : Contiguous, Slice;
 
     enum ror = [
         [0, 1, 2, 3],

--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -1414,8 +1414,7 @@ version(mir_test) unittest
         throw new Exception("total elements count is different or equals to zero");
     }
 
-    auto sl =
-        .iota!int(3, 4)
+    auto sl = iota!int(3, 4)
         .slice
         .universal
         .reversed!0;
@@ -1631,6 +1630,7 @@ Random access and slicing
 nothrow version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
+    import mir.ndslice.slice : sliced;
 
     auto elems = iota(4, 5).slice.flattened;
 
@@ -2326,6 +2326,8 @@ auto bytegroup(size_t pack, DestinationType, T)(auto ref T withAsSlice)
 @safe pure nothrow @nogc
 version(mir_test) unittest
 {
+    import mir.ndslice.slice : DeepElementType, sliced;
+
     ubyte[20] data;
     // creates a packed unsigned integer slice with max allowed value equal to `2^^6 - 1 == 63`.
     auto int24ar = data[].bytegroup!(3, int); // 24 bit integers
@@ -2346,6 +2348,7 @@ version(mir_test) unittest
 @safe pure nothrow @nogc
 version(mir_test) unittest
 {
+    import mir.ndslice.slice : DeepElementType, sliced;
     ushort[20] data;
     // creates a packed unsigned integer slice with max allowed value equal to `2^^6 - 1 == 63`.
     auto int48ar = data[].sliced.bytegroup!(3, long); // 48 bit integers
@@ -3038,6 +3041,7 @@ template as(T)
 @safe pure nothrow version(mir_test) unittest
 {
     import mir.ndslice.allocation : slice;
+    import mir.ndslice.slice : Contiguous, Slice;
 
     Slice!(Contiguous, [2], double*)              matrix = slice!double([2, 2], 0);
     Slice!(Contiguous, [2], const(double)*) const_matrix = matrix.as!(const double);
@@ -3187,6 +3191,7 @@ auto pairwiseMapSubSlices(S, Sliceable)(auto ref S indexes, auto ref Sliceable s
 unittest
 {
     import mir.functional: staticArray;
+    import mir.ndslice.slice : sliced;
     auto pairwiseIndexes =[2, 4, 10].sliced;
     auto sliceable = 10.iota;
 
@@ -3556,6 +3561,7 @@ template kronecker(alias fun = product)
 version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
+    import mir.ndslice.slice : sliced;
 
     // eye
     auto a = slice!double([4, 4], 0);
@@ -3593,6 +3599,7 @@ version(mir_test) unittest
 version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
+    import mir.ndslice.slice : sliced;
 
     auto a = [ 1,  2,
                3,  4].sliced(2, 2);

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -euo pipefail
+
+if [ ! -e test_extractor.d ] ; then
+    wget https://raw.githubusercontent.com/dlang/tools/6b7ef76d679563e6fccef2a6b437008d96459e95/tests_extractor.d
+fi
+
+# extract examples
+dub ./tests_extractor.d -i source -o out
+
+# compile the examples
+for file in $(find out -name "*.d") ; do
+    echo "Testing: $file"
+    dmd -de -unittest -Isource -c -o- "$file"
+done

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -12,5 +12,5 @@ dub ./tests_extractor.d -i source -o out
 # compile the examples
 for file in $(find out -name "*.d") ; do
     echo "Testing: $file"
-    dmd -de -unittest -Isource -c -o- "$file"
+    $DMD -de -unittest -Isource -c -o- "$file"
 done


### PR DESCRIPTION
A start at fixing https://github.com/libmir/mir-algorithm/issues/141

The script from Phobos only extracts public top-level unittests (so tests inside a struct are not tested for now).
Also the mapping back from the error message is a bit annoying because it doesn't add empty whitespace, so the line numbers are off.

Anyhow, it's a start.