### PR TITLE
Make mir.ndslice.allocation: stdcUninitSlice & stdcFreeSlice pure

### DIFF
--- a/source/mir/internal/memory.d
+++ b/source/mir/internal/memory.d
@@ -8,13 +8,13 @@ module mir.internal.memory;
 pure nothrow @nogc extern(C)
 {
     ///
-    void*   malloc(size_t size);
+    void*   malloc(size_t size) @safe;
     ///
-    void*   calloc(size_t nmemb, size_t size);
+    void*   calloc(size_t nmemb, size_t size) @safe;
     ///
-    void*   realloc(void* ptr, size_t size);
+    void*   realloc(void* ptr, size_t size) @system;
     ///
-    void    free(void* ptr);
+    void    free(void* ptr) @system;
 }
 
 pure:

--- a/source/mir/ndslice/allocation.d
+++ b/source/mir/ndslice/allocation.d
@@ -559,7 +559,7 @@ See_also:
 +/
 Slice!(T*, N) stdcUninitSlice(T, size_t N)(size_t[N] lengths...)
 {
-    import core.stdc.stdlib: malloc;
+    import mir.internal.memory: malloc;
     immutable len = lengths.lengthsProduct;
     auto ptr = len ? cast(T*) malloc(len * T.sizeof) : null;
     return ptr.sliced(lengths);
@@ -596,7 +596,7 @@ See_also:
 +/
 void stdcFreeSlice(T, size_t N)(Slice!(T*, N) slice)
 {
-    import core.stdc.stdlib: free;
+    import mir.internal.memory: free;
     slice._iterator.free;
 }
 


### PR DESCRIPTION
Also, `malloc` is `@safe`.