### PR TITLE
topology.d: Added label support for SliceKind selectors

### DIFF
--- a/source/mir/ndslice/topology.d
+++ b/source/mir/ndslice/topology.d
@@ -195,6 +195,7 @@ version(mir_test) unittest
     assert(slice._strides == [3, 1]);
 }
 
+///
 @safe pure nothrow
 version(mir_test) unittest
 {
@@ -262,6 +263,7 @@ version(mir_test) unittest
     assert(slice._strides == [3]);
 }
 
+///
 @safe pure nothrow
 version(mir_test) unittest
 {
@@ -327,6 +329,7 @@ version(mir_test) unittest
     assert(slice._strides == [3]);
 }
 
+///
 @safe pure nothrow
 version(mir_test) unittest
 {
@@ -382,6 +385,7 @@ version(mir_test) unittest
     static assert(slice._strides.length == 0);
 }
 
+///
 @safe pure nothrow
 version(mir_test) unittest
 {


### PR DESCRIPTION
Issue: #179 

SliceKind Selectors will copy over labels while returning a new slice.
Modified: Universal, Canonical, assumeCanonical, assumeContiguous

Commands ran:
- [x] dub test
(Cleared trailing white spaces in VS Code )