### PR TITLE
slice.d: Added label support for Slice selectors

### DIFF
--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -998,9 +998,21 @@ public:
     }
 
     /// Strips label off the DataFrame
-    auto stripLabels()()
+    auto values()()
     {
         return Slice!(Iterator, N, kind)(_structure, _iterator);
+    }
+
+    /// Strips label and returns const slice
+    auto valuesConst()()
+    {
+        return Slice!(Iterator, N, kind)(_structure, _iterator).toConst;
+    }
+
+    /// Strips label and returns an immutable slice
+    auto valuesImmutablet()()
+    {
+        return (cast(immutable)Slice!(Iterator, N, kind)(_structure, _iterator)).toImmutable;
     }
 
     /// `opIndex` overload for const slice
@@ -1920,15 +1932,14 @@ public:
             if (this._iterator == rslice._iterator)
                 return true;
         }
+
         import mir.algorithm.iteration : equal;
         static if (__traits(compiles, this.lightScope))
         {
-            static if(this.L != rslice.L)
-                return false;
-            foreach(i; Iota!(this.L))
+            foreach(i; Iota!(min(this.L, rslice.L)))
                 if(this.label!i != rslice.label!i)
                     return false;
-            return equal(this.lightScope.stripLabels(), rslice.lightScope.stripLabels());           
+            return equal(this.lightScope.values, rslice.lightScope.values);           
         }
         else
             return equal(*cast(This*)&this, *cast(This*)&rslice);

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -997,6 +997,12 @@ public:
         return typeof(return)(_lengths[d].lightImmutable, _labels[d]);
     }
 
+    /// Strips label off the DataFrame
+    auto stripLabels()()
+    {
+        return Slice!(Iterator, N, kind)(_structure, _iterator);
+    }
+
     /// `opIndex` overload for const slice
     auto ref opIndex(Indexes...)(Indexes indexes) const @trusted
             if (isPureSlice!Indexes || isIndexedSlice!Indexes)
@@ -1916,7 +1922,14 @@ public:
         }
         import mir.algorithm.iteration : equal;
         static if (__traits(compiles, this.lightScope))
-            return equal(this.lightScope, rslice.lightScope);
+        {
+            static if(this.L != rslice.L)
+                return false;
+            foreach(i; Iota!(this.L))
+                if(this.label!i != rslice.label!i)
+                    return false;
+            return equal(this.lightScope.stripLabels(), rslice.lightScope.stripLabels());           
+        }
         else
             return equal(*cast(This*)&this, *cast(This*)&rslice);
     }

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -491,6 +491,9 @@ struct Structure(size_t N)
 
 private alias LightConstOfLightScopeOf(Iterator) = LightConstOf!(LightScopeOf!Iterator);
 private alias LightImmutableOfLightConstOf(Iterator) = LightImmutableOf!(LightScopeOf!Iterator);
+private alias ImmutableOfUnqualOfPointerTarget(Iterator) = immutable(Unqual!(PointerTarget!Iterator))*;
+private alias ConstOfUnqualOfPointerTarget(Iterator) = const(Unqual!(PointerTarget!Iterator))*;
+
 /++
 Presents an n-dimensional view over a range.
 
@@ -1018,16 +1021,13 @@ public:
     {
         private alias ConstThis = Slice!(const(Unqual!(PointerTarget!Iterator))*, N, kind);
         private alias ImmutableThis = Slice!(immutable(Unqual!(PointerTarget!Iterator))*, N, kind);
-        private alias ImmutableOfUnqualOfPointerTarget(Iterator) = immutable(Unqual!(PointerTarget!Iterator))*;
-        private alias ConstOfUnqualOfPointerTarget(Iterator) = const(Unqual!(PointerTarget!Iterator))*;
 
         /++
         Cast to const and immutable slices in case of underlying range is a pointer.
         +/
         auto toImmutable()() scope return immutable @trusted pure nothrow @nogc
         {
-            alias It = immutable(Unqual!(PointerTarget!Iterator))*;
-            return Slice!(It, N, kind, staticMap!(ImmutableOfUnqualOfPointerTarget, Labels))
+            return Slice!(ImmutableOfUnqualOfPointerTarget!Iterator, N, kind, staticMap!(ImmutableOfUnqualOfPointerTarget, Labels))
                 (_structure, _iterator, _labels);
         }
 
@@ -1035,8 +1035,7 @@ public:
         auto toConst()() scope return const @trusted pure nothrow @nogc
         {
             version(LDC) pragma(inline, true);
-            alias It = const(Unqual!(PointerTarget!Iterator))*;
-            return Slice!(It, N, kind, staticMap!(ConstOfUnqualOfPointerTarget, Labels))
+            return Slice!(ConstOfUnqualOfPointerTarget!Iterator, N, kind, staticMap!(ConstOfUnqualOfPointerTarget, Labels))
                 (_structure, _iterator, _labels);
         }
 

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -1017,7 +1017,7 @@ public:
         return lightImmutable.opIndex(indexes);
     }
 
-    static if (isPointer!Iterator)
+    static if (allSatisfy!(isPointer, Iterator, Labels))
     {
         private alias ConstThis = Slice!(const(Unqual!(PointerTarget!Iterator))*, N, kind);
         private alias ImmutableThis = Slice!(immutable(Unqual!(PointerTarget!Iterator))*, N, kind);

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -3714,7 +3714,7 @@ version(mir_test) unittest
     assert(vector == [5, 7, 9]);
 }
 
-version(mir_test) unittest
+version(mir_test) pure nothrow unittest
 {
     import mir.ndslice.allocation: slice;
     auto df = slice!(double, int, int)(2, 3);
@@ -3723,52 +3723,20 @@ version(mir_test) unittest
     auto lsdf = df.lightScope;
     assert(lsdf.label!0[0] == 1);
     assert(lsdf.label!1[1] == 2);
-}
 
-version(mir_test) unittest
-{
-    import mir.ndslice.allocation: slice;
-    import mir.ndslice.topology: universal;
-    auto df = slice!(double, int, int)(2, 3).universal;
-    df.label[] = [1, 2];
-    df.label!1[] = [1, 2, 3];
     auto immdf = (cast(immutable)df).lightImmutable;
     assert(immdf.label!0[0] == 1);
     assert(immdf.label!1[1] == 2);
-}
 
-version(mir_test) unittest
-{
-    import mir.ndslice.allocation: slice;
-    import mir.ndslice.topology: universal;
-    auto df = slice!(double, int, int)(2, 3).universal;
-    df.label[] = [1, 2];
-    df.label!1[] = [1, 2, 3];
-    auto immdf = df.lightConst;
-    assert(immdf.label!0[0] == 1);
-    assert(immdf.label!1[1] == 2);
-}
+    auto constdf = df.lightConst;
+    assert(constdf.label!0[0] == 1);
+    assert(constdf.label!1[1] == 2);
 
-version(mir_test) unittest
-{
-    import mir.ndslice.allocation: slice;
-    import mir.ndslice.topology: universal;
-    auto df = slice!(double, int, int)(2, 3).universal;
-    df.label[] = [1, 2];
-    df.label!1[] = [1, 2, 3];
-    auto immdf = df.toConst;
-    assert(immdf.label!0[0] == 1);
-    assert(immdf.label!1[1] == 2);
-}
+    auto constdf2 = df.toConst;
+    assert(constdf2.label!0[0] == 1);
+    assert(constdf2.label!1[1] == 2);
 
-version(mir_test) unittest
-{
-    import mir.ndslice.allocation: slice;
-    import mir.ndslice.topology: universal;
-    auto df = slice!(double, int, int)(2, 3).universal;
-    df.label[] = [1, 2];
-    df.label!1[] = [1, 2, 3];
-    auto immdf = (cast(immutable)df).toImmutable;
-    assert(immdf.label!0[0] == 1);
-    assert(immdf.label!1[1] == 2);
+    auto immdf2 = (cast(immutable)df).toImmutable;
+    assert(immdf2.label!0[0] == 1);
+    assert(immdf2.label!1[1] == 2);
 }

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -3698,3 +3698,10 @@ version(mir_test) unittest
     vector.ndassign!"+"= scalar;
     assert(vector == [5, 7, 9]);
 }
+
+unittest
+{
+    import mir.ndslice.allocation: slice;
+    auto df = slice!(double, int,int)(2,4);
+    auto lsdf = df.lightScope;
+}

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -947,13 +947,19 @@ public:
     /// Returns: Mutable slice over immutable data.
     Slice!(LightImmutableOf!Iterator, N, kind, staticMap!(LightImmutableOf, Labels)) lightImmutable()() scope return immutable @property
     {
-        return typeof(return)(_structure, .lightImmutable(_iterator), CallForEach!(.lightImmutable, _labels));
+        auto ret = typeof(return)(_structure, .lightImmutable(_iterator));
+        foreach(i; Iota!L)
+            ret._labels[i] =  .lightImmutable(_labels[i]);
+        return ret;
     }
 
     /// Returns: Mutable slice over const data.
     Slice!(LightConstOf!Iterator, N, kind, staticMap!(LightConstOf, Labels)) lightConst()() scope return const @property @trusted
     {
-        return typeof(return)(_structure, .lightConst(_iterator), CallForEach!(.lightConst, _labels));
+        auto ret = typeof(return)(_structure, .lightConst(_iterator));
+        foreach(i; Iota!L)
+            ret._labels[i] =  .lightConst(_labels[i]);
+        return ret;
     }
 
     /// ditto
@@ -3727,6 +3733,42 @@ version(mir_test) unittest
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto immdf = (cast(immutable)df).lightImmutable;
+    assert(immdf.label!0[0] == 1);
+    assert(immdf.label!1[1] == 2);
+}
+
+version(mir_test) unittest
+{
+    import mir.ndslice.allocation: slice;
+    import mir.ndslice.topology: universal;
+    auto df = slice!(double,int,int)(2,3).universal;
+    df.label[] = [1, 2];
+    df.label!1[] = [1, 2, 3];
+    auto immdf = df.lightConst;
+    assert(immdf.label!0[0] == 1);
+    assert(immdf.label!1[1] == 2);
+}
+
+version(mir_test) unittest
+{
+    import mir.ndslice.allocation: slice;
+    import mir.ndslice.topology: universal;
+    auto df = slice!(double,int,int)(2,3).universal;
+    df.label[] = [1, 2];
+    df.label!1[] = [1, 2, 3];
+    auto immdf = df.toConst;
+    assert(immdf.label!0[0] == 1);
+    assert(immdf.label!1[1] == 2);
+}
+
+version(mir_test) unittest
+{
+    import mir.ndslice.allocation: slice;
+    import mir.ndslice.topology: universal;
+    auto df = slice!(double,int,int)(2,3).universal;
+    df.label[] = [1, 2];
+    df.label!1[] = [1, 2, 3];
+    auto immdf = (cast(immutable)df).toImmutable;
     assert(immdf.label!0[0] == 1);
     assert(immdf.label!1[1] == 2);
 }

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -489,6 +489,8 @@ struct Structure(size_t N)
     sizediff_t[N] strides;
 }
 
+private alias LightConstOfLightScopeOf(Iterator) = LightConstOf!(LightScopeOf!Iterator);
+private alias LightImmutableOfLightConstOf(Iterator) = LightImmutableOf!(LightScopeOf!Iterator);
 /++
 Presents an n-dimensional view over a range.
 
@@ -918,8 +920,6 @@ public:
         assert(slice == [[1, 99], [5, 6]]);
     }
 
-    private alias LightConstOfLightScopeOf(Iterator) = LightConstOf!(LightScopeOf!Iterator);
-    private alias LightImmutableOfLightConstOf(Iterator) = LightImmutableOf!(LightScopeOf!Iterator);
     /++
     Returns: View with stripped out reference counted context.
     The lifetime of the result mustn't be longer then the lifetime of the original slice.
@@ -3717,7 +3717,7 @@ version(mir_test) unittest
 version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
-    auto df = slice!(double,int,int)(2,3);
+    auto df = slice!(double, int, int)(2, 3);
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto lsdf = df.lightScope;
@@ -3729,7 +3729,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: universal;
-    auto df = slice!(double,int,int)(2,3).universal;
+    auto df = slice!(double, int, int)(2, 3).universal;
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto immdf = (cast(immutable)df).lightImmutable;
@@ -3741,7 +3741,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: universal;
-    auto df = slice!(double,int,int)(2,3).universal;
+    auto df = slice!(double, int, int)(2, 3).universal;
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto immdf = df.lightConst;
@@ -3753,7 +3753,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: universal;
-    auto df = slice!(double,int,int)(2,3).universal;
+    auto df = slice!(double, int, int)(2, 3).universal;
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto immdf = df.toConst;
@@ -3765,7 +3765,7 @@ version(mir_test) unittest
 {
     import mir.ndslice.allocation: slice;
     import mir.ndslice.topology: universal;
-    auto df = slice!(double,int,int)(2,3).universal;
+    auto df = slice!(double, int, int)(2, 3).universal;
     df.label[] = [1, 2];
     df.label!1[] = [1, 2, 3];
     auto immdf = (cast(immutable)df).toImmutable;

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -1010,7 +1010,7 @@ public:
     }
 
     /// Strips label and returns an immutable slice
-    auto valuesImmutablet()()
+    auto valuesImmutable()()
     {
         return (cast(immutable)Slice!(Iterator, N, kind)(_structure, _iterator)).toImmutable;
     }
@@ -3750,4 +3750,20 @@ version(mir_test) pure nothrow unittest
     auto immdf2 = (cast(immutable)df).toImmutable;
     assert(immdf2.label!0[0] == 1);
     assert(immdf2.label!1[1] == 2);
+}
+
+version(mir_test) pure nothrow unittest
+{
+    import mir.ndslice.allocation: slice;
+    import mir.ndslice.topology: universal;
+
+    auto df = slice!(double, int, int)(2, 3).universal;
+    auto values = df.values;
+    assert(is(typeof(values) == Slice! (double*, 2, Universal)));
+
+    auto constvalues = df.valuesConst;
+    assert(is(typeof(constvalues) == Slice!(ConstOfUnqualOfPointerTarget!(double*), 2, Universal)));
+
+    auto immvalues = df.valuesImmutable;
+    assert(is(typeof(immvalues) == Slice!(ImmutableOfUnqualOfPointerTarget!(double*), 2, Universal)));
 }


### PR DESCRIPTION
Added labels support for lightScope, lightImmutable, lightConst, toConst

Commands ran:
- [x] dub test

I couldn't find any unittests to add to. Should I write any?