### PR TITLE
Enhance mean to handle N-dimensional slices and seeds

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -25,6 +25,28 @@ import mir.primitives;
 import std.range.primitives: isInputRange;
 import std.traits: isArray, isFloatingPoint;
 
+private U prod(T : U[N], U, size_t N)(T input)
+    if (N > 0)
+{
+    static if (N == 1) {
+        return input[0];
+    } else {
+        U output = input[0];
+        for (size_t i = 1; i < N; i++)
+            output *= input[i];
+        return output;
+    }
+}
+
+version(mir_test) @safe pure nothrow @nogc unittest
+{
+    size_t[1] x = [3];
+    size_t[2] y = [4, 2];
+    
+    assert(x.prod == 3);
+    assert(y.prod == 8);
+}
+
 /++
 Computes the arithmetic mean of `r`, which must be a finite iterable.
 
@@ -36,16 +58,17 @@ template mean(Summation summation = Summation.appropriate)
     ///
     @safe @fmamath sumType!Range
     mean(Range)(Range r)
-        if (hasElementCount!Range
+        if (hasShape!Range
          || hasLength!Range
          || summation == Summation.appropriate
          || summation == Summation.fast
          || summation == Summation.naive)
     {
-        static if (hasElementCount!Range || hasLength!Range)
+        static if (hasShape!Range || hasLength!Range)
         {
-            static if (hasElementCount!Range) {
-                auto n = r.elementCount;
+            static if (hasShape!Range)
+            {
+                auto n = r.shape.prod;
             } else {
                 auto n = r.length;
             }
@@ -66,17 +89,18 @@ template mean(Summation summation = Summation.appropriate)
     
     ///
     @safe @fmamath F
-    mean(Range)(Range r, F seed)
-        if (hasElementCount!Range
+    mean(Range, F)(Range r, F seed)
+        if (hasShape!Range
          || hasLength!Range
          || summation == Summation.appropriate
          || summation == Summation.fast
          || summation == Summation.naive)
     {
-        static if (hasElementCount!Range || hasLength!Range)
+        static if (hasShape!Range || hasLength!Range)
         {
-            static if (hasElementCount!Range) {
-                auto n = r.elementCount;
+            static if (hasShape!Range)
+            {
+                auto n = r.shape.prod;
             } else {
                 auto n = r.length;
             }

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -1937,7 +1937,7 @@ private template SummationAlgo(Summation summation, Range, F)
     }
 }
 
-private T summationInitValue(T)()
+package T summationInitValue(T)()
 {
     static if (__traits(compiles, {T a = 0.0;}))
     {


### PR DESCRIPTION
The mean function currently does not provide the correct result for N-dimensional slices when N > 1. It works with ranges and 1-dimensional slices without issue, but for N-dimensional slices it is dividing by the length of the first dimension. This is also in contrast with the sum function, which can handle N-dimensional slices without issue. 

This PR adjusts the mean formula so that it will calculate the mean of the whole N-dimensional slice. If shape is defined, the product of the elements of its shape is used in the divisor. Otherwise, the function proceeds as before. 

This PR also enables the ability to pass a seed to mean, which can be useful when dealing with integer slices. 

I added a prod function here instead of mir.math.numeric because it looked like I took a different approach. prod in numeric does not work with static arrays and this does. Happy to move if needed.