### PR TITLE
Add center (and average)

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -22,7 +22,7 @@ import core.lifetime: move;
 import mir.math.common: fmamath;
 import mir.math.sum;
 import mir.primitives;
-import std.traits: isArray, isFloatingPoint, isMutable, isIterable;
+import std.traits: isArray, isFloatingPoint, isMutable, isIterable, arity;
 
 /++
 Output range for mean.
@@ -445,7 +445,7 @@ using `centralTendency`.
 Returns:
     The elements in the range r with the average subtracted from them.
 +/
-template center(F, alias centralTendency = mean)
+template center(F, alias centralTendency = mean!(F, Summation.appropriate))
 {
     /++
     Params:
@@ -473,7 +473,7 @@ template center(F, alias centralTendency = mean)
 }
 
 /// ditto
-template center(alias centralTendency = mean)
+template center(alias centralTendency = mean!(Summation.appropriate))
 {
     /++
     Params:
@@ -502,7 +502,7 @@ template center(alias centralTendency = mean)
 
 /// Center vector
 version(mir_test)
-//@safe pure nothrow
+@safe pure nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -557,7 +557,7 @@ unittest
 
 /// Can also pass arguments to average function used by center
 version(mir_test)
-//pure @safe nothrow
+pure @safe nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -22,7 +22,7 @@ import core.lifetime: move;
 import mir.math.common: fmamath;
 import mir.math.sum;
 import mir.primitives;
-import std.traits: isArray, isFloatingPoint, isMutable, isIterable, arity;
+import std.traits: isArray, isFloatingPoint, isMutable, isIterable;
 
 /++
 Output range for mean.

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -445,32 +445,6 @@ using `centralTendency`.
 Returns:
     The elements in the range r with the average subtracted from them.
 +/
-template center(F, alias centralTendency = mean!(F, Summation.appropriate))
-{
-    /++
-    Params:
-        r = range
-    +/
-    @safe pure nothrow
-    auto center(Range)(Range r)
-        if (isIterable!Range)
-    {
-        return centerImpl!F(r, centralTendency(r));
-    }
-    
-    /++
-    Params:
-        r = range
-        average = average
-    +/
-    @safe pure nothrow
-    auto center(Range)(Range r, out F average)
-        if (isIterable!Range)
-    {
-        average = centralTendency(r);
-        return centerImpl!F(r, average);
-    }
-}
 
 /// ditto
 template center(alias centralTendency = mean!(Summation.appropriate))
@@ -483,7 +457,7 @@ template center(alias centralTendency = mean!(Summation.appropriate))
     auto center(Range)(Range r)
         if (isIterable!Range)
     {
-        return .center!(sumType!Range, centralTendency)(r);
+        return centerImpl!(sumType!Range)(r, centralTendency(r));
     }
     
     /++
@@ -496,7 +470,7 @@ template center(alias centralTendency = mean!(Summation.appropriate))
         if (isIterable!Range)
     {
         average = centralTendency(r);
-        return .center!(T, centralTendency)(r, average);
+        return centerImpl!T(r, average);
     }
 }
 

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -433,8 +433,6 @@ using `centralTendency`.
 Returns:
     The elements in the slice with the average subtracted from them.
 +/
-
-/// ditto
 template center(alias centralTendency = mean!(Summation.appropriate))
 {
     import mir.ndslice.slice: Slice, SliceKind, sliced, hasAsSlice;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -459,19 +459,6 @@ template center(alias centralTendency = mean!(Summation.appropriate))
     {
         return centerImpl!(sumType!Range)(r, centralTendency(r));
     }
-    
-    /++
-    Params:
-        r = range
-        average = average
-    +/
-    @safe pure nothrow
-    auto center(Range, T)(Range r, out T average)
-        if (isIterable!Range)
-    {
-        average = centralTendency(r);
-        return centerImpl!T(r, average);
-    }
 }
 
 /// Center vector
@@ -484,13 +471,7 @@ unittest
     import mir.math.common: approxEqual;
 
     auto x = [0.0, 1, 2, 3, 4, 5].sliced;
-    auto result = [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5].sliced;
-    assert(x.center.all!approxEqual(result));
-    
-    //Can also output average
-    double avg;
-    auto y = x.center(avg);
-    assert(avg == 2.5);
+    assert(x.center.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
 }
 
 /// Can center using different averages
@@ -504,8 +485,8 @@ unittest
 
     auto x = [1.0, 2, 3, 4, 5, 6].sliced;
 
-    assert(x.center!mean.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5].sliced));
-    assert(x.center!hmean.all!approxEqual([-1.44898, -0.44898, 0.55102, 1.55102, 2.55102, 3.55102].sliced));
+    assert(x.center!mean.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.center!hmean.all!approxEqual([-1.44898, -0.44898, 0.55102, 1.55102, 2.55102, 3.55102]));
 }
 
 /// Center matrix
@@ -591,7 +572,7 @@ unittest
     assert(x.center!(mean!"precise").all!approxEqual(result));
 
     //Provide the summation type
-    assert(float.max.repeat(3).center!(mean!(double, "fast")).all!approxEqual([0.0, 0, 0].sliced));
+    assert(float.max.repeat(3).center!(mean!(double, "fast")).all!approxEqual([0.0, 0, 0]));
 }
 
 /++

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -440,9 +440,8 @@ template center(alias centralTendency = mean!(Summation.appropriate))
     import mir.ndslice.slice: Slice, SliceKind, sliced, hasAsSlice;
     /++
     Params:
-        slice = slie
+        slice = slice
     +/
-    @safe pure nothrow
     auto center(Iterator, size_t N, SliceKind kind)(
         Slice!(Iterator, N, kind) slice)
     {

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -521,7 +521,7 @@ version(mir_test)
 pure @safe
 unittest
 {
-    import mir.algorithm.iteration: all;
+    import mir.algorithm.iteration: all, equal;
     import mir.math.common: approxEqual;
     import mir.ndslice: fuse;
     import mir.ndslice.topology: alongDim, byDim, map;
@@ -539,19 +539,11 @@ unittest
     // Use byDim with map to compute average of row/column.
     auto xCenterByDim = x.byDim!1.map!center;
     auto resultByDim = result.byDim!1;
-    size_t i = 0;
-    foreach(e; xCenterByDim) {
-        assert(e.all!approxEqual(resultByDim[i]));
-        i++;
-    }
+    assert(xCenterByDim.equal!(equal!approxEqual)(resultByDim));
 
     auto xCenterAlongDim = x.alongDim!0.map!center;
     auto resultAlongDim = result.alongDim!0;
-    i = 0;
-    foreach(e; xCenterAlongDim) {
-        assert(e.all!approxEqual(resultAlongDim[i]));
-        i++;
-    }
+    assert(xCenterByDim.equal!(equal!approxEqual)(resultAlongDim));
 }
 
 /// Can also pass arguments to average function used by center

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -540,7 +540,6 @@ unittest
     auto xCenterByDim = x.byDim!1.map!center;
     auto resultByDim = result.byDim!1;
     size_t i = 0;
-    import std.stdio : writeln;
     foreach(e; xCenterByDim) {
         assert(e.all!approxEqual(resultByDim[i]));
         i++;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -566,7 +566,7 @@ unittest
     import mir.math.common: approxEqual;
 
     //Set sum algorithm or output type
-    static immutable a = [1, 1e100, 1, -1e100];
+    auto a = [1, 1e100, 1, -1e100];
 
     auto x = a.sliced * 10_000;
     auto result = [5000, 1e104 - 5000, 5000, -1e104 - 5000].sliced;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -424,171 +424,28 @@ unittest
     assert(float.max.repeat(3).hmean!(double, "fast").approxEqual(float.max));
 }
 
-///
-enum CentralTendency
+private template centerImpl(F)
 {
-    ///
-    mean,
-    hmean
-    //TODO:
-    ///
-    //median,
-    ///
-    //geometricMean,
-    ///
-    //weightedMean
-}
+    import mir.ndslice.slice: Slice, SliceKind;
 
-/++
-Computes the average of `r`.
-
-Select type of average using CentralTendency. Currently implemented options:
-    1) mean
-    2) hmean
-
-Returns:
-    The average of all the elements in the range r.
-    
-See_also: $(SUBREF sum, Summation, mean, hmean)
-+/
-template average(F, CentralTendency centralTendency = CentralTendency.mean,
-                 Summation summation = Summation.appropriate)
-    if (isMutable!F)
-{
-    static if (centralTendency == CentralTendency.mean)
-        alias average = mean!(F, summation);
-    else static if (centralTendency == CentralTendency.hmean)
-        alias average = hmean!(F, summation);
-    else
-        static assert(0, "average: CentralTendency." ~ centralTendency.stringof ~ " is not implemented");
-}
-
-/// ditto
-template average(CentralTendency centralTendency = CentralTendency.mean,
-                 Summation summation = Summation.appropriate)
-{
-    static if (centralTendency == CentralTendency.mean)
-        alias average = mean!(summation);
-    else static if (centralTendency == CentralTendency.hmean)
-        alias average = hmean!(summation);
-    else
-        static assert(0, "average: CentralTendency." ~ centralTendency.stringof ~ " is not implemented");
-}
-
-///ditto
-template average(F, string centralTendency, string summation = "appropriate")
-{
-    mixin("alias average = .average!(F, CentralTendency." ~ centralTendency ~ ", Summation." ~ summation ~ ");");
-}
-
-///ditto
-template average(string centralTendency, string summation = "appropriate")
-{
-    mixin("alias average = .average!(CentralTendency." ~ centralTendency ~ ", Summation." ~ summation ~ ");");
-}
-
-/// Generic average of vector
-version(mir_test)
-@safe pure nothrow @nogc
-unittest
-{
-    import mir.math.common: approxEqual;
-
-    static immutable x = [20.0, 100.0, 2000.0, 10.0, 5.0, 2.0];
-    
-    assert(x.average!"mean".approxEqual(356.1667));
-    assert(x.average!"hmean".approxEqual(6.97269));
-}
-
-/// Generic average of matrix
-version(mir_test)
-pure @safe
-unittest
-{
-    import mir.math.common: approxEqual;
-    import mir.ndslice.fuse: fuse;
-
-    auto x = [
-        [20.0, 100.0, 2000.0], 
-        [10.0,   5.0,    2.0]
-    ].fuse;
-
-    assert(x.average!"mean".approxEqual(356.1667));
-    assert(x.average!"hmean".approxEqual(6.97269));
-}
-
-/// Column generic average of matrix
-version(mir_test)
-pure @safe
-unittest
-{
-    import mir.algorithm.iteration: all;
-    import mir.math.common: approxEqual;
-    import mir.ndslice: fuse;
-    import mir.ndslice.topology: alongDim, byDim, map;
-
-    auto x = [
-        [20.0, 100.0, 2000.0],
-        [10.0,   5.0,    2.0]
-    ].fuse;
-
-    auto y_mean = [15.0, 52.5, 1001];
-    auto y_hmean = [13.33333, 9.52381, 3.996004];
-
-    // Use byDim or alongDim with map to compute average of row/column.
-    assert(x.byDim!1.map!(average!"mean").all!approxEqual(y_mean));
-    assert(x.alongDim!0.map!(average!"mean").all!approxEqual(y_mean));
-    
-    assert(x.byDim!1.map!(average!"hmean").all!approxEqual(y_hmean));
-    assert(x.alongDim!0.map!(average!"hmean").all!approxEqual(y_hmean));
-}
-
-/// Can also pass arguments to average
-version(mir_test)
-pure @safe nothrow @nogc
-unittest
-{
-    import mir.ndslice.topology: repeat;
-    import mir.math.common: approxEqual;
-
-    //Set sum algorithm or output type
-    static immutable x = [1, 1e-100, 1, -1e-100];
-
-    assert(x.average!("mean", "kb2").approxEqual(0.5));
-    assert(x.average!("mean", "precise").approxEqual(0.5));
-    
-    assert(x.average!("hmean", "kb2").approxEqual(2));
-    assert(x.average!("hmean", "precise").approxEqual(2));
-
-    //Provide the summation type
-    assert(float.max.repeat(3).average!(double, "mean", "fast").approxEqual(float.max));
-    assert(float.max.repeat(3).average!(double, "hmean", "fast").approxEqual(float.max));
-}
-
-private template centerImpl(F, CentralTendency centralTendency, 
-                            Summation summation)
-{
-    @safe pure nothrow
-    auto centerImpl(Range)(Range r, F average)
-        if (isIterable!Range)
+    @safe pure nothrow @nogc
+    auto centerImpl(Iterator, size_t N, SliceKind kind)(
+        Slice!(Iterator, N, kind) slice, F average)
     {
-        static if (__traits(compiles, r - average)) {
-            return r - average;
-        } else {
-            import mir.ndslice.topology: map;
-            return r.map!(a => a - average);
-        }
+        return slice - average;
     }
 }
 
 /++
 Centers `r`, which must be a finite iterable.
 
+By default, `r` is centered by the mean. A custom function may also be provided
+using `centralTendency`.
+
 Returns:
     The elements in the range r with the average subtracted from them.
 +/
-template center(F, CentralTendency centralTendency = CentralTendency.mean,
-                Summation summation = Summation.appropriate)
+template center(F, alias centralTendency = mean)
 {
     /++
     Params:
@@ -598,7 +455,7 @@ template center(F, CentralTendency centralTendency = CentralTendency.mean,
     auto center(Range)(Range r)
         if (isIterable!Range)
     {
-        return centerImpl!(F, centralTendency, summation)(r, r.average!(F, centralTendency, summation));
+        return centerImpl!F(r, centralTendency(r));
     }
     
     /++
@@ -610,14 +467,13 @@ template center(F, CentralTendency centralTendency = CentralTendency.mean,
     auto center(Range)(Range r, out F average)
         if (isIterable!Range)
     {
-        average = r.average!(F, centralTendency, summation);
-        return centerImpl!(F, centralTendency, summation)(r, average);
+        average = centralTendency(r);
+        return centerImpl!F(r, average);
     }
 }
 
 /// ditto
-template center(CentralTendency centralTendency = CentralTendency.mean,
-                Summation summation = Summation.appropriate)
+template center(alias centralTendency = mean)
 {
     /++
     Params:
@@ -627,7 +483,7 @@ template center(CentralTendency centralTendency = CentralTendency.mean,
     auto center(Range)(Range r)
         if (isIterable!Range)
     {
-        return .center!(sumType!Range, centralTendency, summation)(r);
+        return .center!(sumType!Range, centralTendency)(r);
     }
     
     /++
@@ -639,25 +495,14 @@ template center(CentralTendency centralTendency = CentralTendency.mean,
     auto center(Range, T)(Range r, out T average)
         if (isIterable!Range)
     {
-        return .center!(T, centralTendency, summation)(r, average);
+        average = centralTendency(r);
+        return .center!(T, centralTendency)(r, average);
     }
-}
-
-///ditto
-template center(F, string centralTendency, string summation = "appropriate")
-{
-    mixin("alias center = .center!(F, CentralTendency." ~ centralTendency ~ ", Summation." ~ summation ~ ");");
-}
-
-///ditto
-template center(string centralTendency, string summation = "appropriate")
-{
-    mixin("alias center = .center!(CentralTendency." ~ centralTendency ~ ", Summation." ~ summation ~ ");");
 }
 
 /// Center vector
 version(mir_test)
-@safe pure nothrow
+//@safe pure nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -669,9 +514,9 @@ unittest
     assert(x.center.all!approxEqual(result));
     
     //Can also output average
-    double mean;
-    auto y = x.center(mean);
-    assert(mean == 2.5);
+    double avg;
+    auto y = x.center(avg);
+    assert(avg == 2.5);
 }
 
 /// Can center using different averages
@@ -685,8 +530,8 @@ unittest
 
     auto x = [1.0, 2, 3, 4, 5, 6].sliced;
 
-    assert(x.center!"mean".all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5].sliced));
-    assert(x.center!"hmean".all!approxEqual([-1.44898, -0.44898, 0.55102, 1.55102, 2.55102, 3.55102].sliced));
+    assert(x.center!mean.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5].sliced));
+    assert(x.center!hmean.all!approxEqual([-1.44898, -0.44898, 0.55102, 1.55102, 2.55102, 3.55102].sliced));
 }
 
 /// Center matrix
@@ -753,7 +598,7 @@ unittest
 
 /// Can also pass arguments to average function used by center
 version(mir_test)
-pure @safe nothrow
+//pure @safe nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -767,12 +612,12 @@ unittest
     auto x = a.sliced * 10_000;
     auto result = [5000, 1e104 - 5000, 5000, -1e104 - 5000].sliced;
 
-    assert(x.center!("mean", "kbn").all!approxEqual(result));
-    assert(x.center!("mean", "kb2").all!approxEqual(result));
-    assert(x.center!("mean", "precise").all!approxEqual(result));
+    assert(x.center!(mean!"kbn").all!approxEqual(result));
+    assert(x.center!(mean!"kb2").all!approxEqual(result));
+    assert(x.center!(mean!"precise").all!approxEqual(result));
 
     //Provide the summation type
-    assert(float.max.repeat(3).center!(double, "mean", "fast").all!approxEqual([0.0, 0, 0].sliced));
+    assert(float.max.repeat(3).center!(mean!(double, "fast")).all!approxEqual([0.0, 0, 0].sliced));
 }
 
 /++


### PR DESCRIPTION
`CentralTendency` and `average` can easily be expanded in the future to accommodate new functions. 

One potential downside is that other functions that may be passed to average may require something other than `Summation`. I can't think of it now, but it's possible. 

I'm also not sure if `centerImpl` is the best approach, but it works. 