### PR TITLE
Add median

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -24,7 +24,6 @@ import mir.math.common: fmamath;
 import mir.math.sum;
 import mir.primitives;
 import std.traits: isArray, isFloatingPoint, isMutable, isIterable;
-import std.typecons: Flag, No, Yes;
 
 /++
 Output range for mean.
@@ -437,7 +436,7 @@ Returns:
 
 See_also: $(SUBREF mean)
 +/
-template median(F, Flag!"allowModify" allowModify = No.allowModify)
+template median(F, bool allowModify = false)
 {
     F median(Iterator, size_t N, SliceKind kind)(Slice!(Iterator, N, kind) slice)
     {
@@ -445,7 +444,7 @@ template median(F, Flag!"allowModify" allowModify = No.allowModify)
 
         import mir.ndslice.topology: flattened;
 
-        static if (allowModify == No.allowModify) {
+        static if (!allowModify) {
             import mir.ndslice.allocation: rcslice;
             
             if (slice.elementCount > 2) {
@@ -462,7 +461,7 @@ template median(F, Flag!"allowModify" allowModify = No.allowModify)
 }
 
 ///
-template median(Flag!"allowModify" allowModify = No.allowModify)
+template median(bool allowModify = false)
 {
     sumType!(Slice!(Iterator, N, kind))
         median
@@ -528,10 +527,10 @@ unittest {
     import mir.ndslice.slice: sliced;
 
     auto x0 = [9.0, 1, 0, 2, 3, 4, 6, 8, 7, 10, 5].sliced;
-    assert(x0.median!(Yes.allowModify) == 5);
+    assert(x0.median!true == 5);
     
     auto x1 = [9, 1, 0, 2, 3, 4, 6, 8, 7, 10].sliced;
-    assert(x1.median!(float, Yes.allowModify) == 5);
+    assert(x1.median!(float, true) == 5);
 }
 
 /++

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -552,6 +552,51 @@ unittest {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual;
 
+    auto x = [3, 3, 2, 0, 2, 0].sliced;
+    assert(x.median!float.approxEqual(2));
+
+    x[] = [2, 2, 4, 0, 4, 3];
+    assert(x.median!float.approxEqual(2.5));
+    x[] = [1, 4, 5, 4, 4, 3];
+    assert(x.median!float.approxEqual(4));
+    x[] = [1, 5, 3, 5, 2, 2];
+    assert(x.median!float.approxEqual(2.5));
+    x[] = [4, 3, 2, 1, 4, 5];
+    assert(x.median!float.approxEqual(3.5));
+    x[] = [4, 5, 3, 5, 5, 4];
+    assert(x.median!float.approxEqual(4.5));
+    x[] = [3, 3, 3, 0, 0, 1];
+    assert(x.median!float.approxEqual(2));
+    x[] = [4, 2, 2, 1, 2, 5];
+    assert(x.median!float.approxEqual(2));
+    x[] = [2, 3, 1, 4, 5, 5];
+    assert(x.median!float.approxEqual(3.5));
+    x[] = [1, 1, 4, 5, 5, 5];
+    assert(x.median!float.approxEqual(4.5));
+    x[] = [2, 4, 0, 5, 1, 0];
+    assert(x.median!float.approxEqual(1.5));
+    x[] = [3, 5, 2, 5, 4, 2];
+    assert(x.median!float.approxEqual(3.5));
+    x[] = [3, 5, 4, 1, 4, 3];
+    assert(x.median!float.approxEqual(3.5));
+    x[] = [4, 2, 0, 3, 1, 3];
+    assert(x.median!float.approxEqual(2.5));
+    x[] = [100, 4, 5, 0, 5, 1];
+    assert(x.median!float.approxEqual(4.5));
+    x[] = [100, 5, 4, 0, 5, 1];
+    assert(x.median!float.approxEqual(4.5));
+    x[] = [100, 5, 4, 0, 1, 5];
+    assert(x.median!float.approxEqual(4.5));
+    x[] = [4, 5, 100, 1, 5, 0];
+    assert(x.median!float.approxEqual(4.5));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest {
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
     auto x0 = [9.0, 1, 0, 2, 3].sliced;
     assert(x0.median.approxEqual(2));
 

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -95,10 +95,10 @@ version(mir_test)
 }
 
 /++
-Computes the average of `r`, which must be a finite iterable.
+Computes the average of the input.
 
 Returns:
-    The average of all the elements in the range r.
+    The average of all the elements in the input.
 
 See_also: $(SUBREF sum, Summation)
 +/
@@ -108,7 +108,7 @@ template mean(F, Summation summation = Summation.appropriate)
 
     /++
     Params:
-        r = range
+        r = range, must be finite iterable
     +/
     @fmamath F mean(Range)(Range r)
         if (isIterable!Range)
@@ -141,7 +141,7 @@ template mean(Summation summation = Summation.appropriate)
 
     /++
     Params:
-        r = range
+        r = range, must be finite iterable
     +/
     @fmamath sumType!Range mean(Range)(Range r)
         if (isIterable!Range)

--- a/source/mir/ndslice/sorting.d
+++ b/source/mir/ndslice/sorting.d
@@ -86,7 +86,6 @@ version(mir_test_topN) unittest
 
 import mir.ndslice.slice;
 import mir.math.common: optmath;
-import std.typecons: Flag, No, Yes;
 
 @optmath:
 
@@ -405,7 +404,7 @@ void setPivot(alias less, Iterator)(size_t length, ref Iterator l, ref Iterator 
     medianOf!less(l, e, mid, b, r);
 }
 
-void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+void medianOf(alias less, bool leanRight = false, Iterator)
     (ref Iterator a, ref Iterator b) @trusted
 {
    import mir.utility : swapStars;
@@ -416,7 +415,7 @@ void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
     assert(!less(*b, *a));
 }
 
-void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+void medianOf(alias less, bool leanRight = false, Iterator)
     (ref Iterator a, ref Iterator b, ref Iterator c) @trusted
 {
    import mir.utility : swapStars;
@@ -449,12 +448,12 @@ void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
     assert(!less(*c, *b));
 }
 
-void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+void medianOf(alias less, bool leanRight = false, Iterator)
     (ref Iterator a, ref Iterator b, ref Iterator c, ref Iterator d) @trusted
 {
     import mir.utility: swapStars;
 
-    static if (leanRight == No.leanRight)
+    static if (!leanRight)
     {
         // Eliminate the rightmost from the competition
         if (less(*d, *c)) swapStars(c, d); // c <= d
@@ -470,7 +469,7 @@ void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
     }
 }
 
-void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+void medianOf(alias less, bool leanRight = false, Iterator)
     (ref Iterator a, ref Iterator b, ref Iterator c, ref Iterator d, ref Iterator e) @trusted
 {
     import mir.utility: swapStars; // Credit: Teppo Niinimäki

--- a/source/mir/ndslice/sorting.d
+++ b/source/mir/ndslice/sorting.d
@@ -86,6 +86,7 @@ version(mir_test_topN) unittest
 
 import mir.ndslice.slice;
 import mir.math.common: optmath;
+import std.typecons: Flag, No, Yes;
 
 @optmath:
 
@@ -404,10 +405,22 @@ void setPivot(alias less, Iterator)(size_t length, ref Iterator l, ref Iterator 
     medianOf!less(l, e, mid, b, r);
 }
 
-void medianOf(alias less, Iterator)
+void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+    (ref Iterator a, ref Iterator b) @trusted
+{
+   import mir.utility : swapStars;
+
+    if (less(*b, *a)) {
+        swapStars(a, b);
+    }
+    assert(!less(*b, *a));
+}
+
+void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
     (ref Iterator a, ref Iterator b, ref Iterator c) @trusted
 {
-    import mir.utility : swapStars;
+   import mir.utility : swapStars;
+
    if (less(*c, *a)) // c < a
     {
         if (less(*a, *b)) // c < a < b
@@ -436,10 +449,32 @@ void medianOf(alias less, Iterator)
     assert(!less(*c, *b));
 }
 
-void medianOf(alias less, Iterator)
+void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
+    (ref Iterator a, ref Iterator b, ref Iterator c, ref Iterator d) @trusted
+{
+    import mir.utility: swapStars;
+
+    static if (leanRight == No.leanRight)
+    {
+        // Eliminate the rightmost from the competition
+        if (less(*d, *c)) swapStars(c, d); // c <= d
+        if (less(*d, *b)) swapStars(b, d); // b <= d
+        medianOf!less(a, b, c);
+    }
+    else
+    {
+        // Eliminate the leftmost from the competition
+        if (less(*b, *a)) swapStars(a, b); // a <= b
+        if (less(*c, *a)) swapStars(a, c); // a <= c
+        medianOf!less(b, c, d);
+    }
+}
+
+void medianOf(alias less, Flag!"leanRight" leanRight = No.leanRight, Iterator)
     (ref Iterator a, ref Iterator b, ref Iterator c, ref Iterator d, ref Iterator e) @trusted
 {
-    import mir.utility : swapStars;   // Credit: Teppo Niinimäki
+    import mir.utility: swapStars; // Credit: Teppo Niinimäki
+
     version(unittest) scope(success)
     {
         assert(!less(*c, *a));

--- a/source/mir/ndslice/sorting.d
+++ b/source/mir/ndslice/sorting.d
@@ -757,14 +757,12 @@ unittest {
 }
 
 /++
-Reorders `slice` such that `slice[nth]` refers to the element that would fall
-there if the range were fully sorted. In addition, it also partitions `slice`
-such that all elements `e1` from `slice[0]` to `slice[nth]` satisfy
-`!less(slice[nth], e1)`, and all elements `e2` from `slice[nth]` to
-`slice[slice.length]` satisfy `!less(e2, slice[nth])`. Effectively, it finds
-the `nth` smallest (according to `less`) elements in `slice`. Performs an
-expected $(BIGOH slice.length) evaluations of `less` and `swap`, with a worst
-case of $(BIGOH slice.length^^2).
+Partitions `slice`, such that all elements `e1` from `slice[0]` to `slice[nth]` 
+satisfy `!less(slice[nth], e1)`, and all elements `e2` from `slice[nth]` to
+`slice[slice.length]` satisfy `!less(e2, slice[nth])`. This effectively reorders 
+`slice` such that `slice[nth]` refers to the element that would fall there if 
+the range were fully sorted. Performs an expected $(BIGOH slice.length) 
+evaluations of `less` and `swap`, with a worst case of $(BIGOH slice.length^^2).
 
 This function implements an iterative, in-place version of the
 $(HTTP en.wikipedia.org/wiki/Quickselect, quickselect) algorithm. It loops
@@ -791,7 +789,7 @@ See_Also:
 
 +/
 deprecated("This function is experimental")
-template topN(alias less = "a < b", alias pivotFunction = setPivotAt)
+template partitionAt(alias less = "a < b", alias pivotFunction = setPivotAt)
 {
     import mir.functional: naryFun;
 
@@ -800,24 +798,24 @@ template topN(alias less = "a < b", alias pivotFunction = setPivotAt)
         /++
         Sort n-dimensional slice.
         +/
-        void topN(Iterator, size_t N, SliceKind kind)
+        void partitionAt(Iterator, size_t N, SliceKind kind)
             (Slice!(Iterator, N, kind) slice, size_t nth)
         {
-            assert(slice.elementCount > 0, "topN: slice must have elementCount greater than 0");
-            assert(nth >= 0, "topN: nth must be greater than or equal to zero");
-            assert(nth < slice.elementCount, "topN: nth must be less than the elementCount of the slice");
+            assert(slice.elementCount > 0, "partitionAt: slice must have elementCount greater than 0");
+            assert(nth >= 0, "partitionAt: nth must be greater than or equal to zero");
+            assert(nth < slice.elementCount, "partitionAt: nth must be less than the elementCount of the slice");
         
             import mir.ndslice.topology: flattened;
 
-            topNImpl!(less, pivotFunction)(slice.flattened, nth);
+            partitionAtImpl!(less, pivotFunction)(slice.flattened, nth);
         }
     } else {
-        alias topN = .topN!(naryFun!less, pivotFunction);
+        alias partitionAt = .partitionAt!(naryFun!less, pivotFunction);
     }
 }
 
 private @trusted
-void topNImpl(alias less, alias pivotFunction, Iterator, SliceKind kind)(
+void partitionAtImpl(alias less, alias pivotFunction, Iterator, SliceKind kind)(
         Slice!(Iterator, 1, kind) slice, size_t n) 
 {
     import std.algorithm.sorting: pivotPartition;
@@ -863,11 +861,11 @@ void topNImpl(alias less, alias pivotFunction, Iterator, SliceKind kind)(
             static if (__traits(compiles, pivotFunction(slice))) {
                 pivot = pivotFunction(slice);
             } else
-                static assert(0, "topNImpl: pivotFunction does not compile");
+                static assert(0, "partitionAtImpl: pivotFunction does not compile");
         }
 
-        assert(pivot >= 0, "topNImpl: pivotFunction must provide a value greater than zero");
-        assert(pivot < len, "topNImpl: pivotFunction must provide a value less than the length of the slice");
+        assert(pivot >= 0, "partitionAtImpl: pivotFunction must provide a value greater than zero");
+        assert(pivot < len, "partitionAtImpl: pivotFunction must provide a value less than the length of the slice");
         pivot = pivotPartition!less(slice, pivot);
 
         if (n < pivot) {
@@ -889,7 +887,7 @@ unittest {
 
     size_t nth = 2;
     auto x = [3, 1, 5, 2, 0].sliced;
-    x.topN(nth);
+    x.partitionAt(nth);
     assert(x[nth] == 2);
 }
 
@@ -901,7 +899,7 @@ unittest {
 
     size_t nth = 4;
     auto x = [3, 1, 5, 2, 0, 7].sliced(3, 2);
-    x.topN(nth);
+    x.partitionAt(nth);
     assert(x[2, 0] == 5);
 }
 
@@ -913,7 +911,7 @@ unittest {
 
     size_t nth = 2;
     auto x = [3, 1, 5, 2, 0].sliced;
-    x.topN!("a > b")(nth);
+    x.partitionAt!("a > b")(nth);
     assert(x[nth] == 2);
 }
 
@@ -929,7 +927,7 @@ unittest {
 
     size_t nth = 2;
     auto x = [3, 1, 5, 0, 2].sliced;
-    x.topN!("a < b", tail)(nth);
+    x.partitionAt!("a < b", tail)(nth);
     assert(x[nth] == 2);
 }
 
@@ -954,7 +952,7 @@ version(unittest) {
                 foreach (nth; 0 .. x.length)
                 {
                     auto x_i = x.dup;
-                    x_i.topN!(less, pivotFunction)(nth);
+                    x_i.partitionAt!(less, pivotFunction)(nth);
                     if (x_i[nth] != x_sorted[nth]) {
                         result = false;
                         break;


### PR DESCRIPTION
Implementation of `median`, which just uses `topN` primarily for the implementation. 

I also added some of the other `medianOf` functions from phobos, which helped handling small slices. 

I can work on additional improvements for `topN` separately when I get some guidance on these comments:
https://github.com/libmir/mir-algorithm/pull/250#issuecomment-623584804
https://github.com/libmir/mir-algorithm/pull/250#issuecomment-623609532