### PR TITLE
Add fold

### DIFF
--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -17,6 +17,7 @@ $(T2 equal, Compares two slices for equality.)
 $(T2 filter, Filters elements in a range or an ndslice.)
 $(T2 find, Finds backward index.)
 $(T2 findIndex, Finds index.)
+$(T2 fold, Accumulates all elements.)
 $(T2 isSymmetric, Checks if the matrix is symmetric.)
 $(T2 maxIndex, Finds index of the maximum.)
 $(T2 maxPos, Finds backward index of the maximum.)
@@ -3890,4 +3891,134 @@ version(mir_test)
     // filter all elements for each column
     auto rc = matrix.byDim!1.map!filterPositive;
     assert(equal!equal(rc, [ [3, 100], [], [400, 102] ]));
+}
+
+/++
+Implements the homonym function (also known as `accumulate`, $(D
+compress), `inject`, or `foldl`) present in various programming
+languages of functional flavor. The call `fold!(fun)(slice, seed)`
+first assigns `seed` to an internal variable `result`,
+also called the accumulator. Then, for each element `x` in $(D
+slice), `result = fun(result, x)` gets evaluated. Finally, $(D
+result) is returned. The one-argument version `fold!(fun)(slice)`
+works similarly, but it uses the first element of the slice as the
+seed (the slice must be non-empty).
+
+Params:
+    fun = the predicate function to apply to the elements
+
+See_Also:
+    $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
+
+    $(LREF sum) is similar to `fold!((a, b) => a + b)` that offers
+    precise summing of floating point numbers.
+
+    This is functionally equivalent to $(LREF reduce) with the argument order
+    reversed, and without the need to use $(REF_ALTTEXT `tuple`,tuple,std,typecons)
+    for multiple seeds.
++/
+template fold(alias fun)
+{
+    /++
+    Params:
+        slice = A slice, range, and array.
+        seed = An initial accumulation value (optional).
+    Returns:
+        the accumulated result
+    +/
+    @optmath auto fold(Slice, S)(scope Slice slice, S seed)
+    {
+        return reduce!fun(seed, slice);
+    }
+    
+    @optmath auto fold(Slice)(scope Slice slice)
+        if (isIterable!Slice)
+    {
+        static if (isSlice!Slice) {
+            assert(!slice.anyEmpty, "fold: slice may not be empty");
+            import mir.ndslice.topology: flattened;
+            auto temp = slice.flattened;
+            auto seed = temp.front;
+            temp.popFront;
+            return reduce!fun(seed, temp);
+        } else static if (isInputRange!Slice) {
+            auto seed = slice.front;
+            slice.popFront;
+            return reduce!fun(seed, slice);
+        } else {
+            static assert(0, "fold: not implemented for type " ~ Slice.stringof);
+        }
+    }
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.ndslice.topology: map;
+
+    auto arr = [1, 2, 3, 4, 5].sliced;
+
+    // Sum all elements
+    assert(arr.fold!((a, b) => a + b) == 15);
+
+    // Sum all elements with explicit seed
+    assert(arr.fold!((a, b) => a + b)(6) == 21);
+
+    // Can be used in a UFCS chain
+    assert(arr.map!(a => a + 1).fold!((a, b) => a + b) == 20);
+
+    // Return the last element of any range
+    assert(arr.fold!((a, b) => b) == 5);
+}
+
+/// Works for matrices
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+
+    auto arr = [
+        [1, 2, 3], 
+        [4, 5, 6]
+    ].fuse;
+
+    assert(arr.fold!((a, b) => a + b) == 21);
+    assert(arr.fold!((a, b) => a + b)(7) == 28);
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.topology: map;
+
+    int[] arr = [1, 2, 3, 4, 5];
+
+    // Sum all elements
+    assert(arr.fold!((a, b) => a + b) == 15);
+
+    // Sum all elements with explicit seed
+    assert(arr.fold!((a, b) => a + b)(6) == 21);
+
+    // Can be used in a UFCS chain
+    assert(arr.map!(a => a + 1).fold!((a, b) => a + b) == 20);
+
+    // Return the last element of any range
+    assert(arr.fold!((a, b) => b) == 5);
+}
+
+version(mir_test)
+@safe pure nothrow 
+unittest
+{
+    int[] arr = [1];
+    static assert(!is(typeof(arr.fold!())));
+    static assert(!is(typeof(arr.fold!(a => a))));
+    static assert(is(typeof(arr.fold!((a, b) => a))));
+    static assert(is(typeof(arr.fold!((a, b) => a)(1))));
+    assert(arr.length == 1);
 }

--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -3907,31 +3907,22 @@ Params:
 
 See_Also:
     $(HTTP en.wikipedia.org/wiki/Fold_(higher-order_function), Fold (higher-order function))
-
     $(LREF sum) is similar to `fold!((a, b) => a + b)` that offers
     precise summing of floating point numbers.
-
     This is functionally equivalent to $(LREF reduce) with the argument order
-    reversed, and without the need to use $(REF_ALTTEXT `tuple`,tuple,std,typecons)
-    for multiple seeds.
+    reversed.
 +/
 template fold(alias fun)
 {
     /++
     Params:
         slice = A slice, range, and array.
-        seed = An initial accumulation value (optional).
+        seed = An initial accumulation value.
     Returns:
         the accumulated result
     +/
     @optmath auto fold(Slice, S)(scope Slice slice, S seed)
-        if (hasLength!Slice || isInputRange!Slice)
     {
-        static if (hasLength!Slice) {
-            assert(slice.length > 0, "fold: slice must have positive length");
-        } else {
-            assert(!slice.empty, "fold: slice must not be empty");
-        }
         return reduce!fun(seed, slice);
     }
 }

--- a/source/mir/math/numeric.d
+++ b/source/mir/math/numeric.d
@@ -201,7 +201,6 @@ Returns:
 
 See_also: 
 $(MREF mir, algorithm, iteration, reduce)
-
 $(MREF mir, algorithm, iteration, fold)
 +/
 F prod(F, Range)(Range r)

--- a/source/mir/math/numeric.d
+++ b/source/mir/math/numeric.d
@@ -190,7 +190,7 @@ Calculates the product of the elements of the input.
 This function uses a separate exponential accumulation algorithm to calculate the
 product. A consequence of this is that the result must be a floating point type.
 To calculate the product of a type that is not implicitly convertible to a 
-floating point type, use $(MREF mir, algorithm, iteration, reduce). 
+floating point type, use $(MREF mir, algorithm, iteration, reduce) or $(MREF mir, algorithm, iteration, fold). 
 
 /++
 Params:
@@ -199,8 +199,10 @@ Returns:
     The prduct of all the elements in `r`
 +/
 
-TODO
-See_also: $(MREF mir, algorithm, iteration, reduce)
+See_also: 
+$(MREF mir, algorithm, iteration, reduce)
+
+$(MREF mir, algorithm, iteration, fold)
 +/
 F prod(F, Range)(Range r)
     if (isFloatingPoint!F && isIterable!Range)

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -103,7 +103,8 @@ Computes the average of the input.
 Returns:
     The average of all the elements in the input.
 
-See_also: $(SUBREF sum, Summation)
+See_also: 
+    $(SUBREF sum, Summation)
 +/
 template mean(F, Summation summation = Summation.appropriate)
 {
@@ -322,7 +323,8 @@ version(mir_test)
 /++
 Computes the harmonic mean of a range.
 
-See_also: $(SUBREF sum, Summation)
+See_also: 
+    $(SUBREF sum, Summation)
 +/
 template hmean(F, Summation summation = Summation.appropriate)
 {
@@ -593,7 +595,8 @@ Params:
 Returns:
     The geometric average of all the elements in the input.
 
-See_also: $(SUBREF numeric, prod)
+See_also: 
+    $(SUBREF numeric, prod)
 +/
 @fmamath gmeanType!F gmean(F, Range)(Range r)
     if (isFloatingPoint!F && isIterable!Range)
@@ -837,7 +840,8 @@ By default, a copy is made.
 Returns:
     the median of the slice
 
-See_also: $(SUBREF stat, mean)
+See_also: 
+    $(SUBREF stat, mean)
 +/
 template median(F, bool allowModify = false)
 {


### PR DESCRIPTION
The difference between this implementation and the phobos one is that it does not allow multiple functions or `seed`s. Phobos' `reduce` also allows one to not use a `seed`. Instead of adding that to `reduce`, I implemented it in `fold` only. 