### PR TITLE
Add overloads for sum

### DIFF
--- a/source/mir/math/numeric.d
+++ b/source/mir/math/numeric.d
@@ -241,7 +241,7 @@ prodType!Range prod(Range)(Range r)
     if (isIterable!Range)
 {
     import core.lifetime: move;
-
+    
     alias F = typeof(return);
     return .prod!(F, Range)(r.move);
 }
@@ -264,30 +264,16 @@ prodType!Range prod(Range)(Range r, ref long exp)
 
 /++
 Params:
-    val = values
+    ar = values
 Returns:
-    The prduct of all the elements in `val`
+    The prduct of all the elements in `ar`
 +/
-F prod(F)(scope const F[] val...)
-    if (isFloatingPoint!F)
-{
-    ProdAccumulator!F prod;
-    prod.put(val);
-    return prod.prod;
-}
-
-/++
-Params:
-    val = values
-Returns:
-    The prduct of all the elements in `val`
-+/
-prodType!(CommonType!T) prod(T...)(T val)
-    if (T.length > 0 &&
-        !is(CommonType!T == void))
+prodType!T prod(T)(scope const T[] ar...)
 {
     alias F = typeof(return);
-    return .prod!(F)(val);
+    ProdAccumulator!F prod;
+    prod.put(ar);
+    return prod.prod;
 }
 
 /// Product of arbitrary inputs

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -137,8 +137,6 @@ template mean(F, Summation summation = Summation.appropriate)
 /// ditto
 template mean(Summation summation = Summation.appropriate)
 {
-    import std.traits: CommonType;
-
     /++
     Params:
         r = range, must be finite iterable
@@ -151,13 +149,12 @@ template mean(Summation summation = Summation.appropriate)
     
     /++
     Params:
-        val = values
+        ar = values
     +/
-    @fmamath CommonType!T mean(T...)(T val)
-        if (T.length > 0 &&
-            !is(CommonType!T == void))
+    @fmamath sumType!T mean(T)(scope const T[] ar...)
     {
-        return .mean!(CommonType!T, summation)(val);
+        alias F = typeof(return);
+        return .mean!(F, summation)(ar);
     }
 }
 

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -1732,8 +1732,6 @@ template sum(F, Summation summation = Summation.appropriate)
 ///ditto
 template sum(Summation summation = Summation.appropriate)
 {
-    import std.traits: CommonType;
-
     ///
     sumType!Range sum(Range)(Range r)
         if (isIterable!Range)
@@ -1752,12 +1750,10 @@ template sum(Summation summation = Summation.appropriate)
     }
 
     ///
-    sumType!(CommonType!T) sum(T...)(T r)
-        if (T.length > 0 &&
-            !is(CommonType!T == void))
+    sumType!T sum(T)(scope T[] ar...)
     {
-        alias U = typeof(return);
-        return .sum!(U, ResolveSummationType!(summation, U[], U))(r);
+        alias F = typeof(return);
+        return .sum!(F, ResolveSummationType!(summation, F[], F))(ar);
     }
 }
 

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -1750,7 +1750,7 @@ template sum(Summation summation = Summation.appropriate)
     }
 
     ///
-    sumType!T sum(T)(scope T[] ar...)
+    sumType!T sum(T)(scope const T[] ar...)
     {
         alias F = typeof(return);
         return .sum!(F, ResolveSummationType!(summation, F[], F))(ar);


### PR DESCRIPTION
This PR adds the overloads for `sum` that exist for `prod` and some of the other statistical functions already. 