### PR TITLE
Add variance

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -464,6 +464,10 @@ unittest
 /++
 Computes the mean of the input.
 
+Params:
+    F: controls type of output
+    meanAlgo: algorithm for calculating mean (default: MeanAlgo.precise)
+    summation: algorithm for calculating sums (default: Summation.appropriate)
 Returns:
     The mean of all the elements in the input, must be floating point or complex
 
@@ -794,6 +798,10 @@ unittest
 /++
 Computes the harmonic mean of the input.
 
+Params:
+    F: controls type of output
+    meanAlgo: algorithm for calculating mean (default: MeanAlgo.precise)
+    summation: algorithm for calculating sums (default: Summation.appropriate)
 Returns:
     harmonic mean of all the elements of the input, must be floating point
 

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1933,13 +1933,14 @@ unittest
     auto a = [1, 1e100, 1, -1e100];
 
     auto x = a.sliced * 10_000;
+
     //Due to Floating Point precision, subtracting the mean from the second
     //and fourth numbers in `x` does not change the value of the result
     auto result = [5000, 1e104, 5000, -1e104].sliced;
 
-    assert(x.center!(mean!"kbn") == result);
-    assert(x.center!(mean!"kb2") == result);
-    assert(x.center!(mean!"precise") == result);
+    assert(x.center!(mean!("precise", "kbn")) == result);
+    assert(x.center!(mean!("precise", "kb2")) == result);
+    assert(x.center!(mean!("precise", "precise")) == result);
 }
 
 /++

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -2003,7 +2003,7 @@ Params:
     summation: algorithm for calculating sums (default: Summation.appropriate)
 
 Returns:
-    The elements in the slice with the average subtracted from them.
+    The variance of the input
 +/
 template variance(
     F, 
@@ -2068,27 +2068,15 @@ template variance(
 }
 
 /// ditto
-template variance(F, string varianceAlgo, string summation)
+template variance(F, string varianceAlgo, string summation = "appropriate")
 {
     mixin("alias variance = .variance!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
 }
 
 /// ditto
-template variance(string varianceAlgo, string summation)
+template variance(string varianceAlgo, string summation = "appropriate")
 {
     mixin("alias variance = .variance!(VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
-}
-
-/// ditto
-template variance(F, string varianceAlgo)
-{
-    mixin("alias variance = .variance!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation.appropriate);");
-}
-
-/// ditto
-template variance(string varianceAlgo)
-{
-    mixin("alias variance = .variance!(VarianceAlgo." ~ varianceAlgo ~ ", Summation.appropriate);");
 }
 
 ///
@@ -2156,14 +2144,14 @@ unittest
     ].fuse;
     auto result = [13.16667 / 2, 7.041667 / 2, 0.1666667 / 2, 30.16667 / 2];
 
-    // Use byDim or alongDim with map to compute mean of row/column.
+    // Use byDim or alongDim with map to compute variance of row/column.
     assert(x.byDim!1.map!variance.all!approxEqual(result));
     assert(x.alongDim!0.map!variance.all!approxEqual(result));
 
     // FIXME
-    // Without using map, computes the mean of the whole slice
-    // assert(x.byDim!1.mean == x.sliced.mean);
-    // assert(x.alongDim!0.mean == x.sliced.mean);
+    // Without using map, computes the variance of the whole slice
+    // assert(x.byDim!1.variance == x.sliced.variance);
+    // assert(x.alongDim!0.variance == x.sliced.variance);
 }
 
 /// Can also set algorithm type
@@ -2189,7 +2177,7 @@ unittest
 
 /// Can also set algorithm or output type
 version(mir_test)
-//@safe pure nothrow
+@safe pure nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -2234,7 +2222,7 @@ type is correct. By default, if an input type is not floating point, then the
 result will be a double if it is implicitly convertible to a floating point type.
 +/
 version(mir_test)
-//@safe pure nothrow
+@safe pure nothrow
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -2251,7 +2239,7 @@ unittest
 }
 
 /++
-Mean works for complex numbers and other user-defined types (provided they
+Variance works for complex numbers and other user-defined types (provided they
 can be converted to a floating point or complex type)
 +/
 version(mir_test)
@@ -2265,7 +2253,7 @@ unittest
     assert(x.variance.approxEqual((0.0+10.0i)/ 3));
 }
 
-/// Compute mean tensors along specified dimention of tensors
+/// Compute variance tensors along specified dimention of tensors
 version(mir_test)
 @safe pure
 unittest

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -189,12 +189,12 @@ struct MeanAccumulator(T, Summation summation)
     ///
     size_t count;
     ///
-    Summator!(T, summation) sumAccumulator;
+    Summator!(T, summation) summator;
 
     ///
     F mean(F = T)() @property
     {
-        return cast(F) sumAccumulator.sum / cast(F) count;
+        return cast(F) summator.sum / cast(F) count;
     }
 
     ///
@@ -204,14 +204,14 @@ struct MeanAccumulator(T, Summation summation)
         static if (hasShape!Range)
         {
             count += r.elementCount;
-            sumAccumulator.put(r);
+            summator.put(r);
         }
         else
         {
             foreach(x; r)
             {
                 count++;
-                sumAccumulator.put(x);
+                summator.put(x);
             }
         }
     }
@@ -220,7 +220,7 @@ struct MeanAccumulator(T, Summation summation)
     void put()(T x)
     {
         count++;
-        sumAccumulator.put(x);
+        summator.put(x);
     }
 }
 
@@ -337,7 +337,7 @@ unittest
     
     assert(mean!float([0, 1, 2, 3, 4, 5].sliced(3, 2)) == 2.5);
     
-    assert(is(typeof(mean!float([1, 2, 3])) == float));
+    static assert(is(typeof(mean!float([1, 2, 3])) == float));
 }
 
 /// Mean of vector
@@ -373,23 +373,24 @@ version(mir_test)
 unittest
 {
     import mir.ndslice.fuse: fuse;
-    import mir.ndslice.slice: sliced;
     import mir.ndslice.topology: alongDim, byDim, map;
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
 
     auto x = [
         [0.0, 1.0, 1.5, 2.0, 3.5, 4.25],
         [2.0, 7.5, 5.0, 1.0, 1.5, 0.0]
     ].fuse;
-    auto result = [1, 4.25, 3.25, 1.5, 2.5, 2.125].sliced;
+    auto result = [1, 4.25, 3.25, 1.5, 2.5, 2.125];
 
     // Use byDim or alongDim with map to compute mean of row/column.
-    assert(x.byDim!1.map!mean == result);
-    assert(x.alongDim!0.map!mean == result);
+    assert(x.byDim!1.map!mean.all!approxEqual(result));
+    assert(x.alongDim!0.map!mean.all!approxEqual(result));
 
     // FIXME
     // Without using map, computes the mean of the whole slice
-    // assert(x.sliced(2, 6).byDim!1.mean == x.sliced.mean);
-    // assert(x.sliced(2, 6).alongDim!0.mean == x.sliced.mean);
+    // assert(x.byDim!1.mean == x.sliced.mean);
+    // assert(x.alongDim!0.mean == x.sliced.mean);
 }
 
 /// Can also set algorithm or output type
@@ -398,7 +399,7 @@ version(mir_test)
 unittest
 {
     import mir.ndslice.slice: sliced;
-    import mir.ndslice.topology: map, repeat;
+    import mir.ndslice.topology: repeat;
 
     //Set sum algorithm or output type
 
@@ -417,7 +418,7 @@ unittest
 /++
 For integral slices, pass output type as template parameter to ensure output
 type is correct. By default, if an input type is not floating point, then the
-result will be a dobule if it is implicitly convertible to a floating point type.
+result will be a double if it is implicitly convertible to a floating point type.
 +/
 version(mir_test)
 @safe pure nothrow
@@ -733,7 +734,7 @@ unittest
 /++
 For integral slices, pass output type as template parameter to ensure output
 type is correct. By default, if an input type is not floating point, then the
-result will be a dobule if it is implicitly convertible to a floating point type.
+result will be a double if it is implicitly convertible to a floating point type.
 +/
 version(mir_test)
 @safe pure nothrow
@@ -986,7 +987,7 @@ unittest
     
     assert(gmean!float([1, 2, 3, 4, 5, 6].sliced(3, 2)).approxEqual(2.99379516));
     
-    assert(is(typeof(gmean!float([1, 2, 3])) == float));
+    static assert(is(typeof(gmean!float([1, 2, 3])) == float));
 }
 
 /// Geometric mean of vector
@@ -1065,7 +1066,7 @@ unittest
 /++
 For integral slices, pass output type as template parameter to ensure output
 type is correct. By default, if an input type is not floating point, then the
-result will be a dobule if it is implicitly convertible to a floating point type.
+result will be a double if it is implicitly convertible to a floating point type.
 +/
 version(mir_test)
 @safe pure nothrow
@@ -1626,6 +1627,789 @@ unittest
     assert(x.center!(mean!"kbn") == result);
     assert(x.center!(mean!"kb2") == result);
     assert(x.center!(mean!"precise") == result);
+}
+
+struct MapSummator(alias fun, T, Summation summation) 
+    if(isMutable!T)
+{
+    import mir.functional: naryFun;
+
+    ///
+    Summator!(T, summation) mapSummator;
+
+    ///
+    F sum(F = T)() @property
+    {
+        return cast(F) mapSummator.sum;
+    }
+    
+    ///
+    void put(Range)(Range r)
+        if (isIterable!Range)
+    {
+        static if (hasShape!Range)
+        {
+            import mir.ndslice.topology: map;
+            mapSummator.put(r.map!(a => naryFun!(fun)(a)));
+        }
+        else
+        {
+            foreach(x; r)
+            {
+                mapSummator.put(naryFun!(fun)(x));
+            }
+        }
+    }
+
+    ///
+    void put()(T x)
+    {
+        mapSummator.put(naryFun!(fun)(x));
+    }
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: powi;
+
+    alias f = (double x) => (powi(x, 2));
+    MapSummator!(f, double, Summation.pairwise) x;
+    x.put([0.0, 1, 2, 3, 4].sliced);
+    assert(x.sum == 30.0);
+    x.put(5);
+    assert(x.sum == 55.0);
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+
+    MapSummator!("a + 1", double, Summation.pairwise) x;
+    x.put([0.0, 1, 2, 3, 4].sliced);
+    assert(x.sum == 15.0);
+    x.put(5);
+    assert(x.sum == 21.0);
+}
+
+version(mir_test)
+@safe pure @nogc nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+
+    MapSummator!("a + 1", double, Summation.pairwise) x;
+    static immutable a = [0.0, 1, 2, 3, 4];
+    x.put(a.sliced);
+    assert(x.sum == 15.0);
+    x.put(5);
+    assert(x.sum == 21.0);
+}
+
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.ndslice.fuse: fuse;
+
+    MapSummator!("a + 1", double, Summation.pairwise) x;
+    auto a = [
+        [0.0, 1, 2],
+        [3.0, 4, 5]
+    ].fuse;
+    auto b = [6.0, 7, 8].sliced;
+    x.put(a);
+    assert(x.sum == 21.0);
+    x.put(b);
+    assert(x.sum == 45.0);
+}
+
+/++
+Variance algorithms.
+
+See Also:
+    $(WEB en.wikipedia.org/wiki/Algorithms_for_calculating_variance, Algorithms for calculating variance).
++/
+enum VarianceAlgo
+{
+    /++
+    Performs Welford's online algorithm for updating variance. When
+    calculating variance initially (not an update), the two-pass algorithm is 
+    used, whereby the input is first centered and then the sum of squares is 
+    calculated from that.    
+    +/
+    online,
+    
+    /++
+    Calculates variance using E(x^^2) - E(x)^2 (alowing for adjustments for 
+    population/sample variance). This algorithm can be numerically unstable.
+    +/
+    naive
+}
+
+private
+@safe pure nothrow @nogc
+T square(T)(scope const T x)
+{
+    import mir.internal.utility: isFloatingPoint;
+    import mir.math.common: powi;
+
+    static if (isFloatingPoint!T) {
+        return powi(x, 2);
+    } else static if (__traits(compiles, {
+        T val = T.init * T.init;
+    })) {
+        return x * x;
+    } else {
+        static assert(0, "square: cannot square type: " ~ T.stringof);
+    }
+}
+
+@safe pure nothrow @nogc
+unittest {
+    int x = square(4);
+    assert(x == 16);
+    double y = square(5.0);
+	assert(y == 25);
+    
+    static assert(is(typeof(square(4)) == int));
+    static assert(is(typeof(square(5.0)) == double));
+}
+
+private
+mixin template variance_ops(T, Summation summation)
+{
+
+
+    ///
+    MeanAccumulator!(T, summation) meanAccumulator;
+
+    ///
+    size_t count() @property
+    {
+        return meanAccumulator.count;
+    }
+}
+
+///
+struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
+    if (isMutable!T && varianceAlgo == VarianceAlgo.naive)
+{
+    mixin variance_ops!(T, summation);
+
+    ///
+    MapSummator!(square, T, summation) sumOfSquares;
+    
+    ///
+    this(Range)(Range r)
+        if (isIterable!Range)
+    {
+        this.put(r);
+    }
+    
+    ///
+    this()(T x)
+    {
+        this.put(x);
+    }
+    
+    ///
+    void put(Range)(Range r)
+        if (isIterable!Range)
+    {
+        static if (hasShape!Range)
+        {
+            meanAccumulator.put(r);
+            sumOfSquares.put(r);
+        }
+        else
+        {
+            foreach(x; r)
+            {
+                meanAccumulator.put(x);
+                sumOfSquares.put(x);
+            }
+        }
+    }
+
+    ///
+    void put()(T x)
+    {
+        meanAccumulator.put(x);
+        sumOfSquares.put(x);
+    }
+    
+    ///
+    F variance(F = T)(bool isPopulation) @property
+    {
+        if (isPopulation == false)
+            return cast(F) sumOfSquares.sum / cast(F) (count - 1) - 
+                square(cast(F) meanAccumulator.mean) * (cast(F) count / cast(F) (count - 1));
+        else
+            return cast(F) sumOfSquares.sum / cast(F) count - 
+                square(cast(F) meanAccumulator.mean);
+    }
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    enum PopulationTrue = true;
+    enum PopulationFalse = false;
+
+    VarianceAccumulator!(double, VarianceAlgo.naive, Summation.naive) v;
+    v.put(x);
+    assert(v.variance(true).approxEqual(54.76562 / 12));
+    assert(v.variance(PopulationTrue).approxEqual(54.76562 / 12));
+    assert(v.variance(false).approxEqual(54.76562 / 11));
+    assert(v.variance(PopulationFalse).approxEqual(54.76562 / 11));
+    
+    v.put(4.0);
+    assert(v.variance(true).approxEqual(57.01923 / 13));
+    assert(v.variance(PopulationTrue).approxEqual(57.01923 / 13));
+    assert(v.variance(false).approxEqual(57.01923 / 12));
+    assert(v.variance(PopulationFalse).approxEqual(57.01923 / 12));
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    enum PopulationTrue = true;
+    enum PopulationFalse = false;
+
+    auto v = VarianceAccumulator!(double, VarianceAlgo.naive, Summation.naive)(x);
+    assert(v.variance(true).approxEqual(54.76562 / 12));
+    assert(v.variance(PopulationTrue).approxEqual(54.76562 / 12));
+    assert(v.variance(false).approxEqual(54.76562 / 11));
+    assert(v.variance(PopulationFalse).approxEqual(54.76562 / 11));
+    
+    v.put(4.0);
+    assert(v.variance(true).approxEqual(57.01923 / 13));
+    assert(v.variance(PopulationTrue).approxEqual(57.01923 / 13));
+    assert(v.variance(false).approxEqual(57.01923 / 12));
+    assert(v.variance(PopulationFalse).approxEqual(57.01923 / 12));
+}
+
+///
+struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
+    if (isMutable!T && 
+        varianceAlgo == VarianceAlgo.online)
+{
+    mixin variance_ops!(T, summation);
+
+    ///
+    MapSummator!(square, T, summation) centeredSumOfSquares;
+
+    ///
+    this()(T x)
+    {
+        meanAccumulator.put(x);
+        centeredSumOfSquares.put(cast(T) 0);
+    }
+    
+    ///
+    this(Range)(Range r)
+        if (isIterable!Range)
+    {
+        import mir.ndslice.topology: vmap;
+        import mir.ndslice.internal: LeftOp;
+
+        meanAccumulator.put(r);
+        centeredSumOfSquares.put(r.vmap(LeftOp!("-", T)(meanAccumulator.mean)));
+    }
+
+    ///
+    void put(Range)(Range r)
+        if (isIterable!Range)
+    {
+        T oldMean;
+        if (count > 0)
+            oldMean = meanAccumulator.mean;
+        else
+            oldMean = cast(T) 0;
+
+        meanAccumulator.put(r);
+        static if (hasShape!Range)
+        {
+            import mir.ndslice.topology: vmap, map, zip;
+            import mir.ndslice.internal: LeftOp;
+
+            centeredSumOfSquares.
+                mapSummator.
+                put(
+                    r.vmap(LeftOp!("-", T)(meanAccumulator.mean)).
+                    zip(r.vmap(LeftOp!("-", T)(oldMean))).
+                    map!"a * b"
+                    );
+        }
+        else
+        {
+            foreach(x; r)
+            {
+                centeredSumOfSquares.
+                    mapSummator.
+                    put((x - meanAccumulator.mean) * (x - oldMean));
+            }
+        }
+    }
+    
+    ///
+    void put()(T x)
+    {
+        T oldMean;
+        if (count > 0)
+            oldMean = meanAccumulator.mean;
+        else
+            oldMean = cast(T) 0;
+
+        meanAccumulator.put(x);
+        centeredSumOfSquares.
+            mapSummator.
+            put((x - meanAccumulator.mean) * (x - oldMean));
+    }
+
+    ///
+    F variance(F = T)(bool isPopulation) @property
+    {
+        if (isPopulation == false)
+            return cast(F) centeredSumOfSquares.sum / cast(F) (count - 1);
+        else
+            return cast(F) centeredSumOfSquares.sum / cast(F) count;
+    }
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    enum PopulationTrue = true;
+    enum PopulationFalse = false;
+
+    auto v = VarianceAccumulator!(double, VarianceAlgo.online, Summation.naive)(x);
+    assert(v.variance(true).approxEqual(54.76562 / 12));
+    assert(v.variance(PopulationTrue).approxEqual(54.76562 / 12));
+    assert(v.variance(false).approxEqual(54.76562 / 11));
+    assert(v.variance(PopulationFalse).approxEqual(54.76562 / 11));
+
+    v.put(4.0);
+    assert(v.variance(true).approxEqual(57.01923 / 13));
+    assert(v.variance(PopulationTrue).approxEqual(57.01923 / 13));
+    assert(v.variance(false).approxEqual(57.01923 / 12));
+    assert(v.variance(PopulationFalse).approxEqual(57.01923 / 12));
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    enum PopulationTrue = true;
+    enum PopulationFalse = false;
+
+    VarianceAccumulator!(double, VarianceAlgo.online, Summation.naive) v;
+    v.put(x);
+    assert(v.variance(true).approxEqual(54.76562 / 12));
+    assert(v.variance(PopulationTrue).approxEqual(54.76562 / 12));
+    assert(v.variance(false).approxEqual(54.76562 / 11));
+    assert(v.variance(PopulationFalse).approxEqual(54.76562 / 11));
+
+    v.put(4.0);
+    assert(v.variance(true).approxEqual(57.01923 / 13));
+    assert(v.variance(PopulationTrue).approxEqual(57.01923 / 13));
+    assert(v.variance(false).approxEqual(57.01923 / 12));
+    assert(v.variance(PopulationFalse).approxEqual(57.01923 / 12));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [1.0 + 3i, 2, 3].sliced;
+
+    VarianceAccumulator!(cdouble, VarianceAlgo.online, Summation.naive) v;
+    v.put(x);
+    assert(v.variance(true).approxEqual((-4.0 - 6i) / 3));
+    assert(v.variance(false).approxEqual((-4.0 - 6i) / 2));
+}
+
+/++
+Calculates the variance of the input
+
+Params:
+    F: controls type of output
+    varianceAlgo: algorithm for calculating variance (default: VarianceAlgo.online)
+    summation: algorithm for calculating sums (default: Summation.appropriate)
+
+Returns:
+    The elements in the slice with the average subtracted from them.
++/
+template variance(
+    F, 
+    VarianceAlgo varianceAlgo = VarianceAlgo.online, 
+    Summation summation = Summation.appropriate)
+{
+    /++
+    Params:
+        r = range, must be finite iterable
+        isPopulation: true if population variace, false if sample variance (default)
+    +/
+    @fmamath meanType!F variance(Range)(Range r, bool isPopulation = false)
+        if (isIterable!Range)
+    {
+        import core.lifetime: move;
+        alias G = typeof(return);
+        auto varianceAccumulator = VarianceAccumulator!(G, varianceAlgo, ResolveSummationType!(summation, Range, G))(r.move);
+        return varianceAccumulator.variance(isPopulation);
+    }
+
+    /++
+    Params:
+        ar = values
+    +/
+    @fmamath meanType!F variance(scope const F[] ar...)
+    {
+        alias G = typeof(return);
+        auto varianceAccumulator = VarianceAccumulator!(G, varianceAlgo, ResolveSummationType!(summation, const(G)[], G))(ar);
+        return varianceAccumulator.variance(false);
+    }
+}
+
+/// ditto
+template variance(
+    VarianceAlgo varianceAlgo = VarianceAlgo.online, 
+    Summation summation = Summation.appropriate)
+{
+    /++
+    Params:
+        r = range, must be finite iterable
+        isPopulation: true if population variace, false if sample variance (default)
+    +/
+    @fmamath meanType!Range variance(Range)(Range r, bool isPopulation = false)
+        if(isIterable!Range)
+    {
+        import core.lifetime: move;
+        alias F = typeof(return);
+        return .variance!(F, varianceAlgo, summation)(r.move, isPopulation);
+    }
+
+    /++
+    Params:
+        ar = values
+    +/
+    @fmamath meanType!T variance(T)(scope const T[] ar...)
+    {
+        alias F = typeof(return);
+        return .variance!(F, varianceAlgo, summation)(ar);
+    }
+}
+
+/// ditto
+template variance(F, string varianceAlgo, string summation)
+{
+    mixin("alias variance = .variance!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
+}
+
+/// ditto
+template variance(string varianceAlgo, string summation)
+{
+    mixin("alias variance = .variance!(VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
+}
+
+/// ditto
+template variance(F, string varianceAlgo)
+{
+    mixin("alias variance = .variance!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation.appropriate);");
+}
+
+/// ditto
+template variance(string varianceAlgo)
+{
+    mixin("alias variance = .variance!(VarianceAlgo." ~ varianceAlgo ~ ", Summation.appropriate);");
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    assert(variance([1.0, 2, 3]).approxEqual(2.0 / 2));
+    assert(variance([1.0, 2, 3], true).approxEqual(2.0 / 3));
+
+    assert(variance([1.0 + 3i, 2, 3]).approxEqual((-4.0 - 6i) / 2));
+    
+    assert(variance!float([0, 1, 2, 3, 4, 5].sliced(3, 2)).approxEqual(17.5 / 5));
+    
+    static assert(is(typeof(variance!float([1, 2, 3])) == float));
+}
+
+/// Variance of vector
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    assert(x.variance.approxEqual(54.76562 / 11));
+}
+
+/// Variance of matrix
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.math.common: approxEqual;
+
+    auto x = [
+        [0.0, 1.0, 1.5, 2.0, 3.5, 4.25],
+        [2.0, 7.5, 5.0, 1.0, 1.5, 0.0]
+    ].fuse;
+
+    assert(x.variance.approxEqual(54.76562 / 11));
+}
+
+/// Column variance of matrix
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.topology: alongDim, byDim, map;
+    import mir.math.common: approxEqual;
+    import mir.algorithm.iteration: all;
+
+    auto x = [
+        [0.0,  1.0, 1.5, 2.0], 
+        [3.5, 4.25, 2.0, 7.5],
+        [5.0,  1.0, 1.5, 0.0]
+    ].fuse;
+    auto result = [13.16667 / 2, 7.041667 / 2, 0.1666667 / 2, 30.16667 / 2];
+
+    // Use byDim or alongDim with map to compute mean of row/column.
+    assert(x.byDim!1.map!variance.all!approxEqual(result));
+    assert(x.alongDim!0.map!variance.all!approxEqual(result));
+
+    // FIXME
+    // Without using map, computes the mean of the whole slice
+    // assert(x.byDim!1.mean == x.sliced.mean);
+    // assert(x.alongDim!0.mean == x.sliced.mean);
+}
+
+/// Can also set algorithm type
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto a = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    auto x = a + 1_000_000_000;
+
+    auto y = x.variance;
+    assert(y.approxEqual(54.76562 / 11));
+
+    // The naive algorithm is numerically unstable in this case
+    auto z = x.variance!"naive";
+    assert(!z.approxEqual(y));
+}
+
+/// Can also set algorithm or output type
+version(mir_test)
+//@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.ndslice.topology: repeat;
+    import mir.math.common: approxEqual;
+
+    //Set population variance, variance algorithm, sum algorithm or output type
+
+    auto a = [1.0, 1e100, 1, -1e100].sliced;
+    auto x = a * 10_000;
+
+    bool populationTrueRT = true;
+    bool populationFalseRT = false;
+    enum PopulationTrueCT = true;
+
+    /++
+    Due to Floating Point precision, when centering `x`, subtracting the mean 
+    from the second and fourth numbers has no effect. Further, after centering 
+    and squaring `x`, the first and third numbers in the slice have precision 
+    too low to be included in the centered sum of squares. 
+    +/
+    assert(x.variance(populationFalseRT).approxEqual(2.0e208 / 3));
+    assert(x.variance(populationTrueRT).approxEqual(2.0e208 / 4));
+    assert(x.variance(PopulationTrueCT).approxEqual(2.0e208 / 4));
+
+    assert(x.variance!("online").approxEqual(2.0e208 / 3));
+    assert(x.variance!("online", "kbn").approxEqual(2.0e208 / 3));
+    assert(x.variance!("online", "kb2").approxEqual(2.0e208 / 3));
+    assert(x.variance!("online", "precise").approxEqual(2.0e208 / 3));
+    assert(x.variance!(double, "online", "precise").approxEqual(2.0e208 / 3));
+    assert(x.variance!(double, "online", "precise")(populationTrueRT).approxEqual(2.0e208 / 4));
+
+    auto y = uint.max.repeat(3);
+    auto z = y.variance!ulong;
+    assert(z == 0.0);
+    static assert(is(typeof(z) == double));
+}
+
+/++
+For integral slices, pass output type as template parameter to ensure output
+type is correct. By default, if an input type is not floating point, then the
+result will be a double if it is implicitly convertible to a floating point type.
++/
+version(mir_test)
+//@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0, 1, 1, 2, 4, 4,
+              2, 7, 5, 1, 2, 0].sliced;
+
+    auto y = x.variance;
+    assert(y.approxEqual(50.91667 / 11));
+    static assert(is(typeof(y) == double));
+
+    assert(x.variance!float.approxEqual(50.91667 / 11));
+}
+
+/++
+Mean works for complex numbers and other user-defined types (provided they
+can be converted to a floating point or complex type)
++/
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [1.0 + 2i, 2 + 3i, 3 + 4i, 4 + 5i].sliced;
+    assert(x.variance.approxEqual((0.0+10.0i)/ 3));
+}
+
+/// Compute mean tensors along specified dimention of tensors
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.topology: as, iota, alongDim, map, repeat;
+
+    auto x = [
+        [0.0, 1, 2],
+        [3.0, 4, 5]
+    ].fuse;
+
+    assert(x.variance.approxEqual(17.5 / 5));
+
+    auto m0 = [4.5, 4.5, 4.5];
+    assert(x.alongDim!0.map!variance.all!approxEqual(m0));
+    assert(x.alongDim!(-2).map!variance.all!approxEqual(m0));
+
+    auto m1 = [1.0, 1.0];
+    assert(x.alongDim!1.map!variance.all!approxEqual(m1));
+    assert(x.alongDim!(-1).map!variance.all!approxEqual(m1));
+
+    assert(iota(2, 3, 4, 5).as!double.alongDim!0.map!variance.all!approxEqual(repeat(3600.0 / 2, 3, 4, 5)));
+}
+
+/// Arbitrary variance
+version(mir_test)
+@safe pure nothrow @nogc
+unittest
+{
+    assert(variance(1.0, 2, 3) == 1.0);
+    assert(variance!float(1, 2, 3) == 1f);
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual;
+    assert([1.0, 2, 3, 4].variance.approxEqual(5.0 / 3));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.topology: iota, alongDim, map;
+    import mir.math.common: approxEqual;
+    import mir.algorithm.iteration: all;
+
+    auto x = iota([2, 2], 1);
+    auto y = x.alongDim!1.map!variance;
+    assert(y.all!approxEqual([0.5, 0.5]));
+    static assert(is(meanType!(typeof(y)) == double));
+}
+
+version(mir_test)
+@safe pure @nogc nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    static immutable x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+                          2.0, 7.5, 5.0, 1.0, 1.5, 0.0];
+
+    assert(x.sliced.variance.approxEqual(54.76562 / 11));
+    assert(x.sliced.variance!float.approxEqual(54.76562 / 11));
 }
 
 /++

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1785,7 +1785,7 @@ unittest {
 private
 mixin template variance_ops(T, Summation summation)
 {
-
+    import core.lifetime: move;
 
     ///
     MeanAccumulator!(T, summation) meanAccumulator;
@@ -1812,8 +1812,8 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     {
         static if (hasShape!Range)
         {
-            meanAccumulator.put(r);
-            sumOfSquares.put(r);
+            meanAccumulator.put(r.move);
+            sumOfSquares.put(r.move);
         }
         else
         {
@@ -1892,12 +1892,12 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
         import mir.ndslice.internal: LeftOp;
 
         if (count == 0) {
-            meanAccumulator.put(r);
-            centeredSumOfSquares.put(r.vmap(LeftOp!("-", T)(meanAccumulator.mean)));
+            meanAccumulator.put(r.move);
+            centeredSumOfSquares.put(r.move.vmap(LeftOp!("-", T)(meanAccumulator.mean)));
         } else {
             T oldMean = meanAccumulator.mean;
 
-            meanAccumulator.put(r);
+            meanAccumulator.put(r.move);
             static if (hasShape!Range)
             {
                 import mir.ndslice.topology: vmap, map, zip;
@@ -1906,8 +1906,8 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
                 centeredSumOfSquares.
                     mapSummator.
                     put(
-                        r.vmap(LeftOp!("-", T)(meanAccumulator.mean)).
-                        zip(r.vmap(LeftOp!("-", T)(oldMean))).
+                        r.move.vmap(LeftOp!("-", T)(meanAccumulator.mean)).
+                        zip(r.move.vmap(LeftOp!("-", T)(oldMean))).
                         map!"a * b"
                         );
             }

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1632,8 +1632,6 @@ unittest
 struct MapSummator(alias fun, T, Summation summation) 
     if(isMutable!T)
 {
-    import mir.functional: naryFun;
-
     ///
     Summator!(T, summation) mapSummator;
 
@@ -1650,13 +1648,13 @@ struct MapSummator(alias fun, T, Summation summation)
         static if (hasShape!Range)
         {
             import mir.ndslice.topology: map;
-            mapSummator.put(r.map!(a => naryFun!(fun)(a)));
+            mapSummator.put(r.map!fun);
         }
         else
         {
             foreach(x; r)
             {
-                mapSummator.put(naryFun!(fun)(x));
+                mapSummator.put(fun(x));
             }
         }
     }
@@ -1664,7 +1662,7 @@ struct MapSummator(alias fun, T, Summation summation)
     ///
     void put()(T x)
     {
-        mapSummator.put(naryFun!(fun)(x));
+        mapSummator.put(fun(x));
     }
 }
 
@@ -1690,7 +1688,8 @@ unittest
 {
     import mir.ndslice.slice: sliced;
 
-    MapSummator!("a + 1", double, Summation.pairwise) x;
+    alias f = (double x) => (x + 1);
+    MapSummator!(f, double, Summation.pairwise) x;
     x.put([0.0, 1, 2, 3, 4].sliced);
     assert(x.sum == 15.0);
     x.put(5);
@@ -1703,7 +1702,8 @@ unittest
 {
     import mir.ndslice.slice: sliced;
 
-    MapSummator!("a + 1", double, Summation.pairwise) x;
+    alias f = (double x) => (x + 1);
+    MapSummator!(f, double, Summation.pairwise) x;
     static immutable a = [0.0, 1, 2, 3, 4];
     x.put(a.sliced);
     assert(x.sum == 15.0);
@@ -1718,7 +1718,8 @@ unittest
     import mir.ndslice.slice: sliced;
     import mir.ndslice.fuse: fuse;
 
-    MapSummator!("a + 1", double, Summation.pairwise) x;
+    alias f = (double x) => (x + 1);
+    MapSummator!(f, double, Summation.pairwise) x;
     auto a = [
         [0.0, 1, 2],
         [3.0, 4, 5]

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1854,7 +1854,13 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
         meanAccumulator.put(x);
         sumOfSquares.put(square(x));
     }
-    
+
+    ///
+    F mean(F = T)() @property
+    {
+        return cast(F) meanAccumulator.mean;
+    }
+
     ///
     F variance(F = T)(bool isPopulation) @property
     {
@@ -1911,7 +1917,7 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     size_t count;
 
     ///
-    T mean = cast(T) 0;
+    private T _mean = cast(T) 0;
 
     ///
     void put(Range)(Range r)
@@ -1927,9 +1933,9 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     void put()(T x)
     {
         count += 1;
-        T delta = x - mean;
-        mean += delta / count;
-        centeredSumOfSquares.put(delta * (x - mean));
+        T delta = x - _mean;
+        _mean += delta / count;
+        centeredSumOfSquares.put(delta * (x - _mean));
     }
 
     ///
@@ -1937,9 +1943,15 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     {
         size_t oldCount = this.count;
         this.count += v.count;
-        T delta = v.mean - this.mean;
-        this.mean += delta * v.count / this.count;
+        T delta = v.mean - _mean;
+        _mean += delta * v.count / this.count;
         this.centeredSumOfSquares.put(v.centeredSumOfSquares.sum + delta * delta * v.count * oldCount / this.count);
+    }
+
+    ///
+    F mean(F = T)() @property
+    {
+        return _mean;
     }
 
     ///
@@ -2101,6 +2113,12 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     {
         meanAccumulator.put(x);
         centeredSumOfSquares.put(cast(T) 0);
+    }
+
+    ///
+    F mean(F = T)() @property
+    {
+        return cast(F) meanAccumulator.mean;
     }
 
     ///


### PR DESCRIPTION
This PR adds a `variance` function to `mir.stat`. 

I wanted to do one moment function before moving on to `skewess`, `kurtosis`, and the others to make sure the general structure is correct.