### PR TITLE
Add dispersion function

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -2510,6 +2510,306 @@ unittest
     assert(x.sliced.variance!float.approxEqual(54.76562 / 11));
 }
 
+private
+@safe pure nothrow @nogc
+T square(T)(scope const T x)
+{
+    import mir.internal.utility: isFloatingPoint;
+    import mir.math.common: powi;
+
+    static if (isFloatingPoint!T) {
+        return powi(x, 2);
+    } else static if (__traits(compiles, {
+        T val = T.init * T.init;
+    })) {
+        return x * x;
+    } else {
+        static assert(0, "square: cannot square type: " ~ T.stringof);
+    }
+}
+
+@safe pure nothrow @nogc
+unittest {
+    int x = square(4);
+    assert(x == 16);
+    double y = square(5.0);
+	assert(y == 25);
+    
+    static assert(is(typeof(square(4)) == int));
+    static assert(is(typeof(square(5.0)) == double));
+}
+
+/++
+Calculates the dispersion of the input.
+
+For an input `x`, this function first centers `x` by subtracting each `e` in `x`
+by the result of `centralTendency`, then it transforms the centered values using
+the function `transform`, and then finally summarizes that information using
+the `summarize` funcion. 
+
+The default functions provided are equivalent to calculating the population
+variance. The `centralTendency` default is the `mean` function, which results
+in the input being centered about the mean. The default `transform` function is 
+`square`, which will square the centered values. The default `summarize` function
+is `mean`, which will return the mean of the squared centered values.
+
+Params:
+    centralTendency: function that will produce the value that the input is centered about, default is `mean`
+    transform: function to transform centered values, default is `square`
+    summarize: function to summarize the transformed centered values, default is `mean`
+
+Returns:
+    The dispersion of the input
++/
+template dispersion(
+    alias centralTendency = mean,
+    alias transform = square,
+    alias summarize = mean)
+{
+    import mir.ndslice.slice: Slice, SliceKind, sliced, hasAsSlice;
+
+    /++
+    Params:
+        slice
+    +/
+    @fmamath auto dispersion(Iterator, size_t N, SliceKind kind)(
+        Slice!(Iterator, N, kind) slice)
+    {
+        import core.lifetime: move;
+        import mir.ndslice.topology: map;
+
+        return summarize(slice.move.center!centralTendency.map!transform);
+    }
+    
+    /// ditto
+    @fmamath auto dispersion(T)(scope const T[] ar...)
+    {
+        return dispersion(ar.sliced);
+    }
+
+    /// ditto
+    @fmamath auto dispersion(T)(T withAsSlice)
+        if (hasAsSlice!T)
+    {
+        return dispersion(withAsSlice.asSlice);
+    }
+}
+
+///
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    assert(dispersion([1.0, 2, 3]).approxEqual(2.0 / 3));
+
+    assert(dispersion([1.0 + 3i, 2, 3]).approxEqual((-4.0 - 6i) / 3));
+    
+    assert(dispersion!(mean!float, square, mean!float)([0, 1, 2, 3, 4, 5].sliced(3, 2)).approxEqual(17.5 / 6));
+    
+    static assert(is(typeof(dispersion!(mean!float, square, mean!float)([1, 2, 3])) == float));
+}
+
+/// Dispersion of vector
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    assert(x.dispersion.approxEqual(54.76562 / 12));
+}
+
+/// Dispersion of matrix
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.math.common: approxEqual;
+
+    auto x = [
+        [0.0, 1.0, 1.5, 2.0, 3.5, 4.25],
+        [2.0, 7.5, 5.0, 1.0, 1.5, 0.0]
+    ].fuse;
+
+    assert(x.dispersion.approxEqual(54.76562 / 12));
+}
+
+/// Column dispersion of matrix
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.ndslice.topology: alongDim, byDim, map;
+    import mir.math.common: approxEqual;
+    import mir.algorithm.iteration: all;
+
+    auto x = [
+        [0.0,  1.0, 1.5, 2.0], 
+        [3.5, 4.25, 2.0, 7.5],
+        [5.0,  1.0, 1.5, 0.0]
+    ].fuse;
+    auto result = [13.16667 / 3, 7.041667 / 3, 0.1666667 / 3, 30.16667 / 3];
+
+    // Use byDim or alongDim with map to compute dispersion of row/column.
+    assert(x.byDim!1.map!dispersion.all!approxEqual(result));
+    assert(x.alongDim!0.map!dispersion.all!approxEqual(result));
+
+    // FIXME
+    // Without using map, computes the dispersion of the whole slice
+    // assert(x.byDim!1.dispersion == x.sliced.dispersion);
+    // assert(x.alongDim!0.dispersion == x.sliced.dispersion);
+}
+
+/// Can also set functions to change type of dispersion that is used
+version(mir_test)
+//@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual, fabs, sqrt;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    // Other population variance examples
+    assert(x.dispersion.approxEqual(54.76562 / 12));
+    assert(x.dispersion!mean.approxEqual(54.76562 / 12));
+    assert(x.dispersion!(mean, square).approxEqual(54.76562 / 12));
+    assert(x.dispersion!(mean, square, mean).approxEqual(54.76562 / 12));
+    
+    // Population standard deviation
+    assert(x.dispersion!(mean, square, mean).sqrt.approxEqual(sqrt(54.76562 / 12)));
+    
+    // Mean absolute deviation about the mean
+    assert(x.dispersion!(mean, fabs, mean).approxEqual(21.0 / 12));
+    //Mean absolute deviation about the median
+    assert(x.dispersion!(median, fabs, mean).approxEqual(19.25000 / 12));
+    //Median absolute deviation about the mean
+    assert(x.dispersion!(mean, fabs, median).approxEqual(1.43750));
+    //Median absolute deviation about the median
+    assert(x.dispersion!(median, fabs, median).approxEqual(1.25000));
+}
+
+/++
+For integral slices, pass output type to `centralTendency`, `transform`, and 
+`summary` functions as template parameter to ensure output type is correct.
++/
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [0, 1, 1, 2, 4, 4,
+              2, 7, 5, 1, 2, 0].sliced;
+
+    auto y = x.dispersion;
+    assert(y.approxEqual(50.91667 / 12));
+    static assert(is(typeof(y) == double));
+
+    assert(x.dispersion!(mean!float, square, mean!float).approxEqual(50.91667 / 12));
+}
+
+/++
+Dispersion works for complex numbers and other user-defined types (provided that
+the `centralTendency`, `transform`, and `summary` functions are defined for those
+types)
++/
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    auto x = [1.0 + 2i, 2 + 3i, 3 + 4i, 4 + 5i].sliced;
+    assert(x.dispersion.approxEqual((0.0+10.0i)/ 4));
+}
+
+/// Compute mean tensors along specified dimention of tensors
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse: fuse;
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
+    import mir.ndslice.topology: as, iota, alongDim, map, repeat;
+
+    auto x = [
+        [0.0, 1, 2],
+        [3.0, 4, 5]
+    ].fuse;
+
+    assert(x.dispersion.approxEqual(17.5 / 6));
+
+    auto m0 = [2.25, 2.25, 2.25];
+    assert(x.alongDim!0.map!dispersion.all!approxEqual(m0));
+    assert(x.alongDim!(-2).map!dispersion.all!approxEqual(m0));
+
+    auto m1 = [2.0 / 3, 2.0 / 3];
+    assert(x.alongDim!1.map!dispersion.all!approxEqual(m1));
+    assert(x.alongDim!(-1).map!dispersion.all!approxEqual(m1));
+
+    assert(iota(2, 3, 4, 5).as!double.alongDim!0.map!dispersion.all!approxEqual(repeat(1800.0 / 2, 3, 4, 5)));
+}
+
+/// Arbitrary dispersion
+version(mir_test)
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.math.common: approxEqual;
+
+    assert(dispersion(1.0, 2, 3).approxEqual(2.0 / 3));
+    assert(dispersion!(mean!float, square, mean!float)(1, 2, 3).approxEqual(2f / 3));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual;
+    assert([1.0, 2, 3, 4].dispersion.approxEqual(5.0 / 4));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.topology: iota, alongDim, map;
+    import mir.math.common: approxEqual;
+    import mir.algorithm.iteration: all;
+
+    auto x = iota([2, 2], 1);
+    auto y = x.alongDim!1.map!dispersion;
+    assert(y.all!approxEqual([0.25, 0.25]));
+    static assert(is(meanType!(typeof(y)) == double));
+}
+
+version(mir_test)
+@safe pure @nogc nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual;
+
+    static immutable x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+                          2.0, 7.5, 5.0, 1.0, 1.5, 0.0];
+
+    assert(x.sliced.dispersion.approxEqual(54.76562 / 12));
+}
+
 /++
 A linear regression model with a single explanatory variable.
 +/

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -2513,12 +2513,9 @@ unittest
 @safe pure nothrow @nogc
 T square(T)(scope const T x)
 {
-    import mir.internal.utility: isFloatingPoint;
     import mir.math.common: powi;
 
-    static if (isFloatingPoint!T) {
-        return powi(x, 2);
-    } else static if (__traits(compiles, {
+    static if (__traits(compiles, {
         T val = T.init * T.init;
     })) {
         return x * x;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -2510,7 +2510,6 @@ unittest
     assert(x.sliced.variance!float.approxEqual(54.76562 / 11));
 }
 
-private
 @safe pure nothrow @nogc
 T square(T)(scope const T x)
 {


### PR DESCRIPTION
This function is a generic way to calculate different measures of statistical dispersion, including but not limited to variance (as mean squared deviation), mean absolute deviation, median squared deviation, and median absolute deviation. This function could theoretically handle more general measures of statistical dispersion, such as interquartile range, though this is not tested yet.

I re-used a `square` function from earlier. I tried to replace it without success.

EDIT: Typo