### PR TITLE
Add sweep/scale/zScore

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3286,15 +3286,17 @@ unittest
 }
 
 /++
-For each `e` of the input, applies `e op m` where `op` by default is "-"
-(meaning `e - m`) and `m` is the result of applying `fun` to the input.
+For each `e` of the input, applies `e op m` where `m` is the result of `fun` and
+`op` is an operation, such as `"+"`, `"-"`, `"*"`, or `"/"`. For instance, if
+`op = "-"`, then this function computes `e - m` for each `e` of the input and
+where `m` is the result of applying `fun` to the input.
 
-This function is equivalent to `center` when passing
-`fun = mean!(Summation.appropriate)`.
+Overloads are provided to directly provide `m` to the function, rather than
+calculate it using `fun`.
 
 Params:
     fun = function used to sweep
-    op = operation, default is "-"
+    op = operation
 
 Returns:
     The input 
@@ -3303,7 +3305,7 @@ See_also:
     $(LREF, center),
     $(LREF, scale)
 +/
-template sweep(alias fun, string op = "-")
+template sweep(alias fun, string op)
 {
     import mir.ndslice.slice: Slice, SliceKind, sliced, hasAsSlice;
     import mir.ndslice.topology: vmap;
@@ -3337,9 +3339,9 @@ template sweep(alias fun, string op = "-")
 
 /++
 Params:
-    op = operation, default is "-"
+    op = operation
 +/
-template sweep(string op = "-")
+template sweep(string op)
 {
     /++
     Params:
@@ -3386,8 +3388,8 @@ unittest
     }
 
     auto x = [1.0, 2, 3, 4, 5, 6].sliced;
-    assert(x.sweep!f.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
-    assert(x.sweep(3.5).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!(f, "-").all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!"-"(3.5).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
     assert(x.sweep!(f, "+").all!approxEqual([4.5, 5.5, 6.5, 7.5, 8.5, 9.5]));
 }
 
@@ -3404,8 +3406,8 @@ unittest
     }
 
     auto x = [1.0, 2, 3, 4, 5, 6];
-    assert(x.sweep!f.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
-    assert(x.sweep(3.5).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!(f, "-").all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!"-"(3.5).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
     assert(x.sweep!(f, "+").all!approxEqual([4.5, 5.5, 6.5, 7.5, 8.5, 9.5]));
 }
 
@@ -3437,8 +3439,8 @@ unittest
         [7.5, 8.5, 9.5]
     ];
 
-    assert(x.sweep!f.all!approxEqual(y0));
-    assert(x.sweep(3.5).all!approxEqual(y0));
+    assert(x.sweep!(f, "-").all!approxEqual(y0));
+    assert(x.sweep!"-"(3.5).all!approxEqual(y0));
     assert(x.sweep!(f, "+").all!approxEqual(y1));
 }
 
@@ -3467,11 +3469,11 @@ unittest
     ].fuse;
 
     // Use byDim with map to sweep mean of row/column.
-    auto xSweepByDim = x.byDim!1.map!(sweep!f);
+    auto xSweepByDim = x.byDim!1.map!(sweep!(f, "-"));
     auto resultByDim = result.byDim!1;
     assert(xSweepByDim.equal!(equal!approxEqual)(resultByDim));
 
-    auto xSweepAlongDim = x.alongDim!0.map!(sweep!f);
+    auto xSweepAlongDim = x.alongDim!0.map!(sweep!(f, "-"));
     auto resultAlongDim = result.alongDim!0;
     assert(xSweepAlongDim.equal!(equal!approxEqual)(resultAlongDim));
 }
@@ -3494,9 +3496,9 @@ unittest
     }
 
     auto x = [1.0, 2, 3, 4, 5, 6].sliced;
-    assert(x.sweep!(a => f(a, 3.5)).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!(a => f(a, 3.5), "-").all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
     assert(x.sweep!(a => f(a, 3.5), "+").all!approxEqual([4.5, 5.5, 6.5, 7.5, 8.5, 9.5]));
-    assert(x.sweep!(a => g!3.5(a)).all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.sweep!(a => g!3.5(a), "-").all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
     assert(x.sweep!(a => g!3.5(a), "+").all!approxEqual([4.5, 5.5, 6.5, 7.5, 8.5, 9.5]));
 }
 

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3668,7 +3668,6 @@ is equivalent to `center` when passing `d = 1`.
 Params:
     centralTendency = function used to center input, default is `mean`
     dispersion = function used to , default is `dispersion`
-    centerFirst = centers the input first, before calling `dispersion`, default is false
 
 Returns:
     The scaled result

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3870,7 +3870,7 @@ See_also:
     $(LREF standardDeviation),
     $(LREF variance)
 +/
-template zScore(F, 
+template zscore(F, 
                 VarianceAlgo varianceAlgo = VarianceAlgo.online,
                 Summation summation = Summation.appropriate)
 {
@@ -3879,7 +3879,7 @@ template zScore(F,
         slice = slice
         isPopulation = true if population standard deviation, false is sample (default)
     +/
-    @fmamath auto zScore(Iterator, size_t N, SliceKind kind)(
+    @fmamath auto zscore(Iterator, size_t N, SliceKind kind)(
         Slice!(Iterator, N, kind) slice, 
         bool isPopulation = false)
     {
@@ -3897,64 +3897,64 @@ template zScore(F,
     }
     
     /// ditto
-    @fmamath auto zScore(T)(T[] array, bool isPopulation = false)
+    @fmamath auto zscore(T)(T[] array, bool isPopulation = false)
     {
         import mir.ndslice.slice: sliced;
 
-        return zScore(array.sliced, isPopulation);
+        return zscore(array.sliced, isPopulation);
     }
 
     /// ditto
-    @fmamath auto zScore(T)(T withAsSlice, bool isPopulation = false)
+    @fmamath auto zscore(T)(T withAsSlice, bool isPopulation = false)
         if (hasAsSlice!T)
     {
-        return zScore(withAsSlice.asSlice, isPopulation);
+        return zscore(withAsSlice.asSlice, isPopulation);
     }
 }
 
 ///
-template zScore(VarianceAlgo varianceAlgo = VarianceAlgo.online,
+template zscore(VarianceAlgo varianceAlgo = VarianceAlgo.online,
                 Summation summation = Summation.appropriate)
 {
     /// ditto
-    @fmamath auto zScore(Iterator, size_t N, SliceKind kind)(
+    @fmamath auto zscore(Iterator, size_t N, SliceKind kind)(
         Slice!(Iterator, N, kind) slice, 
         bool isPopulation = false)
     {
         import core.lifetime: move;
         alias F = meanType!(Slice!(Iterator, N, kind));
-        return .zScore!(F, varianceAlgo, summation)(slice.move, isPopulation);
+        return .zscore!(F, varianceAlgo, summation)(slice.move, isPopulation);
     }
 
     /// ditto
-    @fmamath auto zScore(T)(T[] array, bool isPopulation = false)
+    @fmamath auto zscore(T)(T[] array, bool isPopulation = false)
     {
         alias F = meanType!(T[]);
-        return .zScore!(F, varianceAlgo, summation)(array, isPopulation);
+        return .zscore!(F, varianceAlgo, summation)(array, isPopulation);
     }
 
     /// ditto
-    @fmamath auto zScore(T)(T withAsSlice, bool isPopulation = false)
+    @fmamath auto zscore(T)(T withAsSlice, bool isPopulation = false)
         if (hasAsSlice!T)
     {
         alias F = meanType!(T);
-        return .zScore!(F, varianceAlgo, summation)(withAsSlice, isPopulation);
+        return .zscore!(F, varianceAlgo, summation)(withAsSlice, isPopulation);
     }
 }
 
 /// ditto
-template zScore(F, string varianceAlgo, string summation = "appropriate")
+template zscore(F, string varianceAlgo, string summation = "appropriate")
 {
-    mixin("alias zScore = .zScore!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
+    mixin("alias zscore = .zscore!(F, VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
 }
 
 /// ditto
-template zScore(string varianceAlgo, string summation = "appropriate")
+template zscore(string varianceAlgo, string summation = "appropriate")
 {
-    mixin("alias zScore = .zScore!(VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
+    mixin("alias zscore = .zscore!(VarianceAlgo." ~ varianceAlgo ~ ", Summation." ~ summation ~ ");");
 }
 
-/// zScore vector
+/// zscore vector
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3965,11 +3965,11 @@ unittest
 
     auto x = [1.0, 2, 3, 4, 5, 6].sliced;
 
-    assert(x.zScore.all!approxEqual([-1.336306, -0.801784, -0.267261, 0.267261, 0.801784, 1.336306]));
-    assert(x.zScore(true).all!approxEqual([-1.46385, -0.87831, -0.29277, 0.29277, 0.87831, 1.46385]));
+    assert(x.zscore.all!approxEqual([-1.336306, -0.801784, -0.267261, 0.267261, 0.801784, 1.336306]));
+    assert(x.zscore(true).all!approxEqual([-1.46385, -0.87831, -0.29277, 0.29277, 0.87831, 1.46385]));
 }
 
-/// zScore dynamic array
+/// zscore dynamic array
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3978,11 +3978,11 @@ unittest
     import mir.math.common: approxEqual;
 
     auto x = [1.0, 2, 3, 4, 5, 6];
-    assert(x.zScore.all!approxEqual([-1.336306, -0.801784, -0.267261, 0.267261, 0.801784, 1.336306]));
-    assert(x.zScore(true).all!approxEqual([-1.46385, -0.87831, -0.29277, 0.29277, 0.87831, 1.46385]));
+    assert(x.zscore.all!approxEqual([-1.336306, -0.801784, -0.267261, 0.267261, 0.801784, 1.336306]));
+    assert(x.zscore(true).all!approxEqual([-1.46385, -0.87831, -0.29277, 0.29277, 0.87831, 1.46385]));
 }
 
-/// zScore matrix
+/// zscore matrix
 version(mir_test)
 @safe pure
 unittest
@@ -3996,11 +3996,11 @@ unittest
         [4.0, 5, 6]
     ].fuse;
     
-    assert(x.zScore.all!approxEqual([[-1.336306, -0.801784, -0.267261], [0.267261, 0.801784, 1.336306]]));
-    assert(x.zScore(true).all!approxEqual([[-1.46385, -0.87831, -0.29277], [0.29277, 0.87831, 1.46385]]));
+    assert(x.zscore.all!approxEqual([[-1.336306, -0.801784, -0.267261], [0.267261, 0.801784, 1.336306]]));
+    assert(x.zscore(true).all!approxEqual([[-1.46385, -0.87831, -0.29277], [0.29277, 0.87831, 1.46385]]));
 }
 
-/// Column zScore matrix
+/// Column zscore matrix
 version(mir_test)
 @safe pure
 unittest
@@ -4021,11 +4021,11 @@ unittest
     ].fuse;
 
     // Use byDim with map to scale by row/column.
-    auto xScaleByDim = x.byDim!1.map!zScore;
+    auto xScaleByDim = x.byDim!1.map!zscore;
     auto resultByDim = result.byDim!1;
     assert(xScaleByDim.equal!(equal!approxEqual)(resultByDim));
 
-    auto xCenterAlongDim = x.alongDim!0.map!zScore;
+    auto xCenterAlongDim = x.alongDim!0.map!zscore;
     auto resultAlongDim = result.alongDim!0;
     assert(xScaleByDim.equal!(equal!approxEqual)(resultAlongDim));
 }
@@ -4047,13 +4047,13 @@ unittest
 
     auto result = [6.123724e-101, 1.224745, 6.123724e-101, -1.224745].sliced;
 
-    assert(x.zScore!("online", "kbn").all!approxEqual(result));
-    assert(x.zScore!("online", "kb2").all!approxEqual(result));
-    assert(x.zScore!("online", "precise").all!approxEqual(result));
-    assert(x.zScore!(double, "online", "precise").all!approxEqual(result));
+    assert(x.zscore!("online", "kbn").all!approxEqual(result));
+    assert(x.zscore!("online", "kb2").all!approxEqual(result));
+    assert(x.zscore!("online", "precise").all!approxEqual(result));
+    assert(x.zscore!(double, "online", "precise").all!approxEqual(result));
 
     auto y = [uint.max, uint.max / 2, uint.max / 3].sliced;
-    assert(y.zScore!ulong.all!approxEqual([1.120897, -0.320256, -0.800641]));
+    assert(y.zscore!ulong.all!approxEqual([1.120897, -0.320256, -0.800641]));
 }
 
 /++


### PR DESCRIPTION
Adds `scale` and `zScore` functions. `scale` is implemented using `sweep`, and `center` is re-worked to use `sweep`). `sweep` may also have uses on its own. 