### PR TITLE
Add assumeZeroMean VarianceAlgo

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,7 @@ dependency "mir-core" version=">=1.1.7"
 
 buildType "unittest" {
 	buildOptions "unittests" "debugMode" "debugInfo"
-    versions "mir_test" "mir_bignum_test"
+    versions "mir_test"  "mir_bignum_test"
     dflags "-lowmem"
 }
 buildType "unittest-cov" {


### PR DESCRIPTION
This algorithm can be useful when trying to calculate to calculate the `variance` of an already `center`ed slice. Alternately, it can be useful in the context of linear regression where the residuals are assumed to have zero mean. More generally, it can be thought of as just the mean of the squares of the input. It can also be used to obtain the sum of the squares. 