### PR TITLE
Add skewness

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3278,7 +3278,7 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
     }
 }
 
-///
+/// naive
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3386,7 +3386,7 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
     }
 }
 
-///
+/// online
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3416,7 +3416,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((100.238166 / 13) / pow(57.019231 / 12, 1.5) * (13.0 ^^ 2) / (12.0 * 11.0)));
 }
 
-///
+/// Can put slice
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3446,6 +3446,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
 }
 
+// Can put SkewnessAccumulator
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3477,6 +3478,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
 }
 
+// Simpler online test
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3495,6 +3497,7 @@ unittest
     assert(v.skewness(false).approxEqual((100.238166 / 13) / pow(57.019231 / 12, 1.5) * (13.0 ^^ 2) / (12.0 * 11.0)));
 }
 
+// Simpler SkewnessAccumulator put test
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3515,6 +3518,7 @@ unittest
     assert(v.skewness(false).approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
 }
 
+// Confirm large values produce correct answer
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3605,7 +3609,7 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
     }
 }
 
-///
+/// twoPass & threePass
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3634,6 +3638,7 @@ unittest
     assert(w.skewness(PopulationFalseCT).approxEqual(12.000999 / 12 * sqrt(12.0 * 11.0) / 10.0));
 }
 
+// Double-check large values produce correct answer
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3740,7 +3745,7 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
     }
 }
 
-///
+/// assumeZeroMean
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3771,7 +3776,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((181.005859 / 13) / pow(70.765625 / 12, 1.5) * 13.0 ^^ 2 / (12.0 * 11.0)));
 }
 
-///
+/// Can put slices
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3804,6 +3809,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * 12.0 ^^ 2 / (11.0 * 10.0)));
 }
 
+// Can put SkewnessAccumulator
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3838,6 +3844,7 @@ unittest
     assert(v.skewness(PopulationFalseCT).approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * 12.0 ^^ 2 / (11.0 * 10.0)));
 }
 
+// Simpler assumeZeroMean
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -3857,6 +3864,7 @@ unittest
     assert(v.skewness(false).approxEqual((181.005859 / 13) / pow(70.765625 / 12, 1.5) * 13.0 ^^ 2 / (12.0 * 11.0)));
 }
 
+// Can put SkewnessAccumulator
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -4078,6 +4086,7 @@ unittest
     assert(!z3.approxEqual(y));
 }
 
+// Alt version with x a tenth of above's value
 version(mir_test)
 @safe pure
 unittest
@@ -4232,6 +4241,7 @@ unittest
     assert(skewness!float(1, 2, 3) == 0f);
 }
 
+// Check skewness vector UFCS
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -4240,6 +4250,7 @@ unittest
     assert([1.0, 2, 3, 4].skewness.approxEqual(0.0));
 }
 
+// Double-check correct output types
 version(mir_test)
 @safe pure nothrow
 unittest
@@ -4254,6 +4265,7 @@ unittest
     static assert(is(meanType!(typeof(y)) == double));
 }
 
+// @nogc skewness test
 version(mir_test)
 @safe pure @nogc nothrow
 unittest
@@ -4268,6 +4280,7 @@ unittest
     assert(x.sliced.skewness!float.approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
 }
 
+// Test skewness with values
 version(mir_test)
 @safe pure nothrow
 unittest

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3197,20 +3197,20 @@ enum SkewnessAlgo
     /++
     Calculates skewness using
     (E(x^^3) - 3 * mu * sigma ^^ 2 + mu^3) / (sigma ^^ 3) (alowing for
-    adjustments for population/sample variance). This algorithm can be
+    adjustments for population/sample skewness). This algorithm can be
     numerically unstable.
     +/
     naive,
 
     /++
-    Calculates variance using a two-pass algorithm whereby the input is first
+    Calculates skewness using a two-pass algorithm whereby the input is first
     scaled by the mean and variance (using $(LREF VarianceAccumulator.online))
     and then the sum of cubes is calculated from that. 
     +/
     twoPass,
 
     /++
-    Calculates variance using a three-pass algorithm whereby the input is first
+    Calculates skewness using a three-pass algorithm whereby the input is first
     scaled by the mean and variance (using $(LREF VarianceAccumulator.twoPass))
     and then the sum of cubes is calculated from that. 
     +/

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3196,7 +3196,7 @@ enum SkewnessAlgo
     
     /++
     Calculates skewness using
-    (E(x^^3) - 3 * mu * sigma ^^ 2 + mu^3) / (sigma ^^ 3) (alowing for
+    (E(x^^3) - 3 * mu * sigma ^^ 2 + mu ^^ 3) / (sigma ^^ 3) (alowing for
     adjustments for population/sample skewness). This algorithm can be
     numerically unstable.
     +/
@@ -4266,6 +4266,30 @@ unittest
 
     assert(x.sliced.skewness.approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
     assert(x.sliced.skewness!float.approxEqual((117.005859 / 12) / pow(54.765625 / 11, 1.5) * (12.0 ^^ 2) / (11.0 * 10.0)));
+}
+
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.ndslice.slice: sliced;
+    import mir.math.common: approxEqual, pow;
+
+    auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+              2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
+
+    assert(x.skewness.approxEqual(1.149008));
+    assert(x.skewness(true).approxEqual(1.000083));
+    assert(x.skewness!"naive".approxEqual(1.149008));
+    assert(x.skewness!"naive"(true).approxEqual(1.000083));
+    assert(x.skewness!"twoPass".approxEqual(1.149008));
+    assert(x.skewness!"twoPass"(true).approxEqual(1.000083));
+    assert(x.skewness!"threePass".approxEqual(1.149008));
+    assert(x.skewness!"threePass"(true).approxEqual(1.000083));
+
+    auto y = x.center;
+    assert(y.skewness!"assumeZeroMean".approxEqual(1.149008));
+    assert(y.skewness!"assumeZeroMean"(true).approxEqual(1.000083));
 }
 
 /++

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3285,6 +3285,7 @@ unittest
 {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual, pow;
+    import mir.math.sum: Summation;
 
     auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3393,6 +3394,7 @@ unittest
 {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual, pow;
+    import mir.math.sum: Summation;
 
     auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3423,6 +3425,7 @@ unittest
 {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual, pow;
+    import mir.math.sum: Summation;
 
     auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25].sliced;
     auto y = [2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3615,7 +3618,8 @@ version(mir_test)
 unittest
 {
     import mir.ndslice.slice: sliced;
-    import mir.math.common: approxEqual, pow, sqrt;
+    import mir.math.common: approxEqual, sqrt;
+    import mir.math.sum: Summation;
 
     auto x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3644,7 +3648,7 @@ version(mir_test)
 unittest
 {
     import mir.ndslice.slice: sliced;
-    import mir.math.common: approxEqual, pow, sqrt;
+    import mir.math.common: approxEqual, sqrt;
 
     auto a = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3752,6 +3756,7 @@ unittest
 {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual, pow;
+    import mir.math.sum: Summation;
 
     auto a = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;
@@ -3783,6 +3788,7 @@ unittest
 {
     import mir.ndslice.slice: sliced;
     import mir.math.common: approxEqual, pow;
+    import mir.math.sum: Summation;
 
     auto a = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
               2.0, 7.5, 5.0, 1.0, 1.5, 0.0].sliced;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -3341,8 +3341,8 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
         }
         accumulator.put(x);
         T deltaNew = x - accumulator.mean;
-        centeredSumOfCubes.put((deltaOld ^^ 3) * (count - 1) * (count - 2) / (count * count) -
-                               3 * deltaOld * centeredSumOfSquares.sum / count);
+        centeredSumOfCubes.put((deltaOld ^^ 3) * (cast(T) (count - 1) * (count - 2)) / (cast(T) (count * count)) -
+                               3 * deltaOld * centeredSumOfSquares.sum / (cast(T) count));
         centeredSumOfSquares.put(deltaOld * deltaNew);
     }
 
@@ -3356,9 +3356,9 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
         }
         accumulator.put!T(v.accumulator);
         centeredSumOfCubes.put(v.centeredSumOfCubes.sum + 
-                               delta * delta * delta * v.count * oldCount * (oldCount - v.count) / (count * count) +
-                               3 * delta * (oldCount * v.centeredSumOfSquares.sum - v.count * centeredSumOfSquares.sum) / count);
-        centeredSumOfSquares.put(v.centeredSumOfSquares.sum + delta * delta * v.count * oldCount / count);
+                               delta * delta * delta * (cast(T) v.count * oldCount * (oldCount - v.count)) / (cast(T) (count * count)) +
+                               3 * delta * ((cast(T) oldCount) * v.centeredSumOfSquares.sum - (cast(T) v.count) * centeredSumOfSquares.sum) / (cast(T) count));
+        centeredSumOfSquares.put(v.centeredSumOfSquares.sum + delta * delta * (cast(T) v.count * oldCount) / (cast(T) count));
     }
 
     ///
@@ -3371,14 +3371,14 @@ struct SkewnessAccumulator(T, SkewnessAlgo skewnessAlgo, Summation summation)
         if (isPopulation == false) {
             assert(count > 2, "SkewnessAccumulator.skewness: count must be larger than two");
 
-            F varS = centeredSumOfSquares.sum / (count - 1);
+            F varS = centeredSumOfSquares.sum / (cast(F) (count - 1));
             assert(varS > 0, "SkewnessAccumulator.skewness: variance must be larger than zero");
 
             F mult = (cast(F) (count * count)) / (cast(F) (count - 1) * (count - 2));
 
             return (centeredSumOfCubes.sum / cast(F) count) / (varS * varS.sqrt) * mult;
         } else {
-            F varP = centeredSumOfSquares.sum / (count);
+            F varP = centeredSumOfSquares.sum / (cast(F) count);
             assert(varP > 0, "SkewnessAccumulator.skewness: variance must be larger than zero");
 
             return (centeredSumOfCubes.sum / cast(F) count) / (varP * varP.sqrt);


### PR DESCRIPTION
Compared to `VarianceAlgo`, `SkewnessAlgo` has one additional algorithm. I complement `SkewnessAlgo.twoPass` with `SkewnessAlgo.threePass`. 

`SkewnessAlgo.threePass` is the most accurate version because it calculates the `mean` and `variance` first in two passes and then scales each value in the input by them. 

`SkewnessAlgo.twoPass` is similar to above, but calculates the `mean` and `variance` in one pass and then scales the input by them. I include a UT where it provides the same answer as `SkewnessAlgo.online` and `SkewnessAlgo.threePass` and then another where it and `SkewnessAlgo.online` provide the incorrect answer. As with `VarianceAlgo.twoPass`, there are cases where it can be faster to go through a slice twice rather than do the `online` calculation. Nevertheless, I do not have as strong an opinion about whether to include, but it is not much additional effort in the implementation. 