### PR TITLE
Make statistical types public

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1843,7 +1843,6 @@ enum VarianceAlgo
     assumeZeroMean
 }
 
-private
 mixin template moment_ops(T,
                           Summation summation)
 {
@@ -1863,7 +1862,6 @@ mixin template moment_ops(T,
     }
 }
 
-private
 mixin template outputRange_ops(T)
 {
     ///

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -27,6 +27,7 @@ import std.traits: isArray, isMutable, isIterable, isIntegral, CommonType;
 import mir.internal.utility: isFloatingPoint;
 
 ///
+package(mir)
 template statType(T, bool checkComplex = true)
 {
     import mir.internal.utility: isFloatingPoint, isComplex;
@@ -133,6 +134,7 @@ unittest
 }
 
 ///
+package(mir)
 template meanType(T)
 {
     import mir.math.sum: sumType;
@@ -555,6 +557,7 @@ unittest
 }
 
 ///
+package(mir)
 template hmeanType(T)
 {
     import mir.math.sum: sumType;
@@ -948,6 +951,7 @@ unittest
 }
 
 ///
+package(mir)
 template gmeanType(T)
 {
     import mir.math.numeric: prodType;
@@ -1843,6 +1847,7 @@ enum VarianceAlgo
     assumeZeroMean
 }
 
+package(mir)
 mixin template moment_ops(T,
                           Summation summation)
 {
@@ -1862,6 +1867,7 @@ mixin template moment_ops(T,
     }
 }
 
+package(mir)
 mixin template outputRange_ops(T)
 {
     ///
@@ -2797,6 +2803,7 @@ unittest
 }
 
 ///
+package(mir)
 template stdevType(T)
 {
     import mir.internal.utility: isFloatingPoint;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -26,7 +26,8 @@ import mir.primitives;
 import std.traits: isArray, isMutable, isIterable, isIntegral, CommonType;
 import mir.internal.utility: isFloatingPoint;
 
-package template statType(T, bool checkComplex = true)
+///
+template statType(T, bool checkComplex = true)
 {
     import mir.internal.utility: isFloatingPoint, isComplex;
 
@@ -131,7 +132,8 @@ unittest
     static assert(is(statType!Foo == double)); // note: this is not ints
 }
 
-package template meanType(T)
+///
+template meanType(T)
 {
     import mir.math.sum: sumType;
     import mir.internal.utility: isFloatingPoint, isComplex;
@@ -552,7 +554,8 @@ unittest
     assert(x.sliced.mean!float == 29.25 / 12);
 }
 
-package template hmeanType(T)
+///
+template hmeanType(T)
 {
     import mir.math.sum: sumType;
     
@@ -944,7 +947,8 @@ unittest
     assert(x.gmean.approxEqual(2.60517108));
 }
 
-package template gmeanType(T)
+///
+template gmeanType(T)
 {
     import mir.math.numeric: prodType;
     
@@ -2794,7 +2798,8 @@ unittest
     assert(x.sliced.variance!float.approxEqual(54.76562 / 11));
 }
 
-package template stdevType(T)
+///
+template stdevType(T)
 {
     import mir.internal.utility: isFloatingPoint;
     


### PR DESCRIPTION
Needed for `mir-stat` to get `dispersion` UT to pass.