### PR TITLE
Remove moment_ops/outputRange_ops mixins

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1857,9 +1857,12 @@ enum VarianceAlgo
     assumeZeroMean
 }
 
-package(mir)
-mixin template outputRange_ops(T)
+///
+struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
+    if (isMutable!T && varianceAlgo == VarianceAlgo.naive)
 {
+    import mir.functional: naryFun;
+
     ///
     this(Range)(Range r)
         if (isIterable!Range)
@@ -1873,15 +1876,6 @@ mixin template outputRange_ops(T)
     {
         this.put(x);
     }
-}
-
-///
-struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
-    if (isMutable!T && varianceAlgo == VarianceAlgo.naive)
-{
-    import mir.functional: naryFun;
-
-    mixin outputRange_ops!T;
 
     ///
     MeanAccumulator!(T, summation) meanAccumulator;
@@ -1965,7 +1959,19 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     if (isMutable!T && 
         varianceAlgo == VarianceAlgo.online)
 {
-    mixin outputRange_ops!T;
+    ///
+    this(Range)(Range r)
+        if (isIterable!Range)
+    {
+        import core.lifetime: move;
+        this.put(r.move);
+    }
+
+    ///
+    this()(T x)
+    {
+        this.put(x);
+    }
 
     ///
     MeanAccumulator!(T, summation) meanAccumulator;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1858,26 +1858,6 @@ enum VarianceAlgo
 }
 
 package(mir)
-mixin template moment_ops(T,
-                          Summation summation)
-{
-    ///
-    MeanAccumulator!(T, summation) meanAccumulator;
-
-    ///
-    size_t count() @property
-    {
-        return meanAccumulator.count;
-    }
-
-    ///
-    F mean(F = T)() @property
-    {
-        return meanAccumulator.mean;
-    }
-}
-
-package(mir)
 mixin template outputRange_ops(T)
 {
     ///
@@ -1901,8 +1881,22 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
 {
     import mir.functional: naryFun;
 
-    mixin moment_ops!(T, summation);
     mixin outputRange_ops!T;
+
+    ///
+    MeanAccumulator!(T, summation) meanAccumulator;
+
+    ///
+    size_t count() @property
+    {
+        return meanAccumulator.count;
+    }
+
+    ///
+    F mean(F = T)() @property
+    {
+        return meanAccumulator.mean;
+    }
 
     ///
     Summator!(T, summation) sumOfSquares;
@@ -1971,8 +1965,22 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     if (isMutable!T && 
         varianceAlgo == VarianceAlgo.online)
 {
-    mixin moment_ops!(T, summation);
     mixin outputRange_ops!T;
+
+    ///
+    MeanAccumulator!(T, summation) meanAccumulator;
+
+    ///
+    size_t count() @property
+    {
+        return meanAccumulator.count;
+    }
+
+    ///
+    F mean(F = T)() @property
+    {
+        return meanAccumulator.mean;
+    }
 
     ///
     Summator!(T, summation) centeredSumOfSquares;
@@ -2173,7 +2181,20 @@ struct VarianceAccumulator(T, VarianceAlgo varianceAlgo, Summation summation)
     import mir.functional: naryFun;
     import mir.ndslice.slice: Slice, SliceKind, hasAsSlice;
 
-    mixin moment_ops!(T, summation);
+    ///
+    MeanAccumulator!(T, summation) meanAccumulator;
+
+    ///
+    size_t count() @property
+    {
+        return meanAccumulator.count;
+    }
+
+    ///
+    F mean(F = T)() @property
+    {
+        return meanAccumulator.mean;
+    }
 
     ///
     Summator!(T, summation) centeredSumOfSquares;


### PR DESCRIPTION
One motivation for including these was to re-use operations across higher-level moments. With higher-level moments in `mir.stat`, it prompted me to re-think this approach. One issue with these mixins is that they do not show up properly in documentation. The downside is code duplication. 