### PR TITLE
Increase stat code cov

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -544,7 +544,7 @@ unittest
 }
 
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -816,7 +816,7 @@ unittest
 
 /// Arbitrary harmonic mean
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.math.common: approxEqual;
@@ -830,7 +830,7 @@ unittest
 }
 
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.math.common: approxEqual;
@@ -860,7 +860,7 @@ F nthroot(F)(in F x, in size_t n)
 }
 
 version(mir_test)
-@safe @nogc pure nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.math.common: approxEqual;
@@ -1221,7 +1221,7 @@ unittest
 }
 
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -1259,7 +1259,8 @@ template median(F, bool allowModify = false)
     Params:
         slice = slice
     +/
-    meanType!F median(Iterator, size_t N, SliceKind kind)(Slice!(Iterator, N, kind) slice) @nogc
+    @nogc
+    meanType!F median(Iterator, size_t N, SliceKind kind)(Slice!(Iterator, N, kind) slice)
     {
         static assert (!allowModify ||
                        isMutable!(slice.DeepElement),
@@ -1434,6 +1435,23 @@ unittest
     import mir.ndslice.slice: sliced;
     static immutable x = [9.0, 1, 0, 2, 3];
     assert(x.sliced.median == 2);
+}
+
+// withAsSlice test
+version(mir_test)
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.math.common: approxEqual;
+    import mir.rc.array: RCArray;
+
+    static immutable a = [9.0, 1, 0, 2, 3, 4, 6, 8, 7, 10, 5];
+
+    auto x = RCArray!double(11);
+    foreach(i, ref e; x)
+        e = a[i];
+
+    assert(x.median.approxEqual(5));
 }
 
 /++
@@ -1798,12 +1816,13 @@ unittest
     import mir.rc.array: RCArray;
 
     static immutable a = [1.0, 2, 3, 4, 5, 6];
+    static immutable result = [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5];
 
     auto x = RCArray!double(6);
     foreach(i, ref e; x)
         e = a[i];
 
-    assert(x.center.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+    assert(x.center.all!approxEqual(result));
 }
 
 /++
@@ -1867,7 +1886,7 @@ unittest
 }
 
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.ndslice.slice: sliced;
@@ -2937,7 +2956,7 @@ unittest
 }
 
 version(mir_test)
-@safe pure @nogc nothrow
+@safe pure nothrow @nogc
 unittest
 {
     import mir.ndslice.slice: sliced;

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1775,6 +1775,37 @@ unittest
     assert(x.center.standardDeviation!"assumeZeroMean".approxEqual(x.standardDeviation));
 }
 
+// dynamic array test
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
+
+    double[] x = [1.0, 2, 3, 4, 5, 6];
+
+    assert(x.center.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+}
+
+// withAsSlice test
+version(mir_test)
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
+    import mir.rc.array: RCArray;
+
+    static immutable a = [1.0, 2, 3, 4, 5, 6];
+
+    auto x = RCArray!double(6);
+    foreach(i, ref e; x)
+        e = a[i];
+
+    assert(x.center.all!approxEqual([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]));
+}
+
 /++
 Output range that applies function `fun` to each input before summing
 +/
@@ -2315,6 +2346,40 @@ unittest
     assert(v.variance(PopulationTrueCT).approxEqual(54.76562 / 12));
     assert(v.variance(PopulationFalseRT).approxEqual(54.76562 / 11));
     assert(v.variance(PopulationFalseCT).approxEqual(54.76562 / 11));
+}
+
+// dynamic array test
+version(mir_test)
+@safe pure nothrow
+unittest
+{
+    import mir.math.common: approxEqual;
+    import mir.rc.array: RCArray;
+
+    double[] x = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+                  2.0, 7.5, 5.0, 1.0, 1.5, 0.0];
+
+    auto v = VarianceAccumulator!(double, VarianceAlgo.twoPass, Summation.naive)(x);
+    assert(v.centeredSumOfSquares.sum.approxEqual(54.76562));
+}
+
+// withAsSlice test
+version(mir_test)
+@safe pure nothrow @nogc
+unittest
+{
+    import mir.math.common: approxEqual;
+    import mir.rc.array: RCArray;
+
+    static immutable a = [0.0, 1.0, 1.5, 2.0, 3.5, 4.25,
+                          2.0, 7.5, 5.0, 1.0, 1.5, 0.0];
+
+    auto x = RCArray!double(12);
+    foreach(i, ref e; x)
+        e = a[i];
+
+    auto v = VarianceAccumulator!(double, VarianceAlgo.twoPass, Summation.naive)(x);
+    assert(v.centeredSumOfSquares.sum.approxEqual(54.76562));
 }
 
 ///


### PR DESCRIPTION
I've been having some difficulty with `mir.stat.descriptive.quantile` getting `asSlice` to consistently work and figured I should add tests to `mir.math.stat` to ensure the functionality works properly there. 