### PR TITLE
Adjust MovingAverage UT to use MeanAccumulator and be @nogc

### DIFF
--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -202,8 +202,6 @@ unittest
         if (isFloatingPoint!T)
     {
         import mir.math.stat: MeanAccumulator;
-        import mir.ndslice.slice: Slice;
-        import mir.rc.array: RCI;
 
         MeanAccumulator!(T, Summation.precise) meanAccumulator;
         double[] circularBuffer;
@@ -229,8 +227,8 @@ unittest
             import mir.utility: swap;
             meanAccumulator.summator += x;
             swap(circularBuffer[frontIndex++], x);
+            frontIndex = frontIndex == circularBuffer.length ? 0 : frontIndex;
             meanAccumulator.summator -= x;
-            frontIndex %= circularBuffer.length;
         }
     }
 


### PR DESCRIPTION
I did this more too satisfy my own curiosity in terms of potentially adding the same functionality to `mir-stat` at some point in the future.

One of the things I noticed is that `MeanAccumulator` does not have `+` and `-` defined in the same way that `Summator` does. It doesn't really have a big impact in this case because I avoid modifying `count`. However, it means the logic for adjusting it is in `MovingAverage` instead of `MeanAccumulator`. I would guess, without testing myself and not being 100% sure, that when compiling with `-O` the adding and subtraction of count is elided. 