### PR TITLE
Adapt code to support -preview=in

### DIFF
--- a/source/mir/ndslice/internal.d
+++ b/source/mir/ndslice/internal.d
@@ -259,7 +259,7 @@ template DynamicArrayDimensionsCount(T)
         enum size_t DynamicArrayDimensionsCount = 0;
 }
 
-bool isPermutation(size_t N)(auto ref in size_t[N] perm)
+bool isPermutation(size_t N)(auto ref const scope size_t[N] perm)
 {
     int[N] mask;
     return isValidPartialPermutationImpl(perm, mask);
@@ -328,7 +328,7 @@ private enum isReference(P) =
 alias ImplicitlyUnqual(T) = Select!(isImplicitlyConvertible!(T, Unqual!T), Unqual!T, T);
 alias ImplicitlyUnqual(T : T*) = T*;
 
-size_t lengthsProduct(size_t N)(auto ref in size_t[N] lengths)
+size_t lengthsProduct(size_t N)(auto ref const scope size_t[N] lengths)
 {
     size_t length = lengths[0];
     foreach (i; Iota!(1, N))


### PR DESCRIPTION
```
When the switch is provided, '[auto] ref in' becomes illegal in the parser.
This little trick, using static if + mixin, allow to have a different function
based on whether the switch is used or not.
```

If I could  get a point release, that would allow me to make progress with https://github.com/dlang/dmd/pull/11632