### PR TITLE
Address issue 328

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -1549,6 +1549,17 @@ unittest
     assert(x4.median.approxEqual(1));
 }
 
+// Check issue #328 fixed
+version(mir_test)
+@safe pure nothrow
+unittest {
+    import mir.ndslice.topology: iota;
+
+    auto x = iota(18);
+    auto y = median(x);
+    assert(y == 8.5);
+}
+
 private pure @trusted nothrow @nogc
 F smallMedianImpl(F, Iterator)(Slice!Iterator slice) 
 {

--- a/source/mir/ndslice/sorting.d
+++ b/source/mir/ndslice/sorting.d
@@ -1100,7 +1100,7 @@ unittest {
 }
 
 version(unittest) {
-    template checkTopNAll(alias less = "a < b")
+    template checkPartitionAtAll(alias less = "a < b")
     {
         import mir.functional: naryFun;
         import mir.ndslice.slice: SliceKind, Slice;
@@ -1108,7 +1108,7 @@ version(unittest) {
         static if (__traits(isSame, naryFun!less, less))
         {
             @safe pure nothrow
-            static bool checkTopNAll
+            static bool checkPartitionAtAll
                 (Iterator, SliceKind kind)(
                     Slice!(Iterator, 1, kind) x)
             {
@@ -1129,7 +1129,7 @@ version(unittest) {
                 return result;
             }
         } else {
-            alias checkTopNAll = .checkTopNAll!(naryFun!less);
+            alias checkPartitionAtAll = .checkPartitionAtAll!(naryFun!less);
         }
     }
 }
@@ -1139,25 +1139,25 @@ version(mir_test)
 unittest {
     import mir.ndslice.slice: sliced;
 
-    assert(checkTopNAll([2, 2].sliced));
+    assert(checkPartitionAtAll([2, 2].sliced));
     
-    assert(checkTopNAll([3, 1, 5, 2, 0].sliced));
-    assert(checkTopNAll([3, 1, 5, 0, 2].sliced));
-    assert(checkTopNAll([0, 0, 4, 3, 3].sliced));
-    assert(checkTopNAll([5, 1, 5, 1, 5].sliced));
-    assert(checkTopNAll([2, 2, 0, 0, 0].sliced));
+    assert(checkPartitionAtAll([3, 1, 5, 2, 0].sliced));
+    assert(checkPartitionAtAll([3, 1, 5, 0, 2].sliced));
+    assert(checkPartitionAtAll([0, 0, 4, 3, 3].sliced));
+    assert(checkPartitionAtAll([5, 1, 5, 1, 5].sliced));
+    assert(checkPartitionAtAll([2, 2, 0, 0, 0].sliced));
 
-    assert(checkTopNAll([ 2, 12, 10,  8,  1, 20, 19,  1,  2,  7].sliced));
-    assert(checkTopNAll([ 4, 18, 16,  0, 15,  6,  2, 17, 10, 16].sliced));
-    assert(checkTopNAll([ 7,  5,  9,  4,  4,  2, 12, 20, 15, 15].sliced));
+    assert(checkPartitionAtAll([ 2, 12, 10,  8,  1, 20, 19,  1,  2,  7].sliced));
+    assert(checkPartitionAtAll([ 4, 18, 16,  0, 15,  6,  2, 17, 10, 16].sliced));
+    assert(checkPartitionAtAll([ 7,  5,  9,  4,  4,  2, 12, 20, 15, 15].sliced));
 
-    assert(checkTopNAll([17, 87, 58, 50, 34, 98, 25, 77, 88, 79].sliced));
+    assert(checkPartitionAtAll([17, 87, 58, 50, 34, 98, 25, 77, 88, 79].sliced));
 
-    assert(checkTopNAll([ 6,  7, 10, 25,  5, 10,  9,  0,  2, 15,  7,  9, 11,  8, 13, 18, 17, 13, 25, 22].sliced));
-    assert(checkTopNAll([21,  3, 11, 22, 24, 12, 14, 12, 15, 15,  1,  3, 12, 15, 25, 19,  9, 16, 16, 19].sliced));
-    assert(checkTopNAll([22,  6, 18,  0,  1,  8, 13, 13, 16, 19, 23, 17,  4,  6, 12, 24, 15, 20, 11, 17].sliced));
-    assert(checkTopNAll([19, 23, 14,  5, 12,  3, 13,  7, 25, 25, 24,  9, 21, 25, 12, 22, 15, 22,  7, 11].sliced));
-    assert(checkTopNAll([ 0,  2,  7, 16,  2, 20,  1, 11, 17,  5, 22, 17, 25, 13, 14,  5, 22, 21, 24, 14].sliced));
+    assert(checkPartitionAtAll([ 6,  7, 10, 25,  5, 10,  9,  0,  2, 15,  7,  9, 11,  8, 13, 18, 17, 13, 25, 22].sliced));
+    assert(checkPartitionAtAll([21,  3, 11, 22, 24, 12, 14, 12, 15, 15,  1,  3, 12, 15, 25, 19,  9, 16, 16, 19].sliced));
+    assert(checkPartitionAtAll([22,  6, 18,  0,  1,  8, 13, 13, 16, 19, 23, 17,  4,  6, 12, 24, 15, 20, 11, 17].sliced));
+    assert(checkPartitionAtAll([19, 23, 14,  5, 12,  3, 13,  7, 25, 25, 24,  9, 21, 25, 12, 22, 15, 22,  7, 11].sliced));
+    assert(checkPartitionAtAll([ 0,  2,  7, 16,  2, 20,  1, 11, 17,  5, 22, 17, 25, 13, 14,  5, 22, 21, 24, 14].sliced));
 }
 
 private @trusted pure nothrow @nogc
@@ -1381,7 +1381,7 @@ Iterator partitionAtPartition(alias less, Iterator)(
 {
     size_t len = lastI - frontI + 1;
 
-    assert(len >= 9 && n < len, "partitionAtImpl: length must be longer than 9 and n must be less than r.length");
+    assert(len >= 9 && n < len, "partitionAtPartition: length must be longer than 9 and n must be less than r.length");
 
     size_t ninth = len / 9;
     size_t pivot = ninth / 2;


### PR DESCRIPTION
Issue [328](https://github.com/libmir/mir-algorithm/issues/328) results from when calling `median` with a slice of 18 elements. It does not happen with smaller slices because of the branching logic in `partitionAtImpl`. The fix is that the `length` command is used in the original from Phobos, but the iterators are used here and the last iterator is calculated with one minus the length. Adjusting the iterator up by 1 fixes the issue. 