### PR TITLE
Address built-in complex deprecation

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,7 @@ dependency "mir-core" version=">=1.1.67"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"
-    versions "mir_bignum_test" "mir_test"
+    versions "mir_bignum_test" "mir_builtincomplex_test" "mir_test"
     dflags "-lowmem"
 }
 buildType "unittest-dip1008" {

--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -1445,6 +1445,7 @@ template isSymmetric(alias fun = "a == b")
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     import mir.ndslice.topology: iota;
     assert(iota(2, 2).isSymmetric == false);
 
@@ -1580,6 +1581,7 @@ template minmaxPos(alias pred = "a < b")
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
         2, 6, 4, -3,
         0, -4, -3, 3,
@@ -1651,6 +1653,7 @@ template minmaxIndex(alias pred = "a < b")
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
         2, 6, 4, -3,
         0, -4, -3, 3,
@@ -1720,6 +1723,7 @@ template maxPos(alias pred = "a < b")
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
         2, 6, 4, -3,
         0, -4, -3, 3,
@@ -1791,6 +1795,7 @@ template maxIndex(alias pred = "a < b")
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
         2, 6, 4, -3,
         0, -4, -3, 3,
@@ -1812,6 +1817,7 @@ unittest
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
         -8, 6, 4, -3,
         0, -4, -3, 3,
@@ -1827,6 +1833,7 @@ unittest
 version(mir_test)
 unittest
 {
+    import mir.ndslice.slice: sliced;
     auto s = [
             0, 1, 2, 3,
             4, 5, 6, 7,

--- a/source/mir/bignum/fp.d
+++ b/source/mir/bignum/fp.d
@@ -216,6 +216,8 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
+
         auto fp = Fp!128(UInt!128.fromHexString("afbbfae3cd0aff2714a1de7022b0029d"));
         assert(fp.exponent == 0);
         assert(fp.coefficient == UInt!128.fromHexString("afbbfae3cd0aff2714a1de7022b0029d"));
@@ -280,6 +282,8 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
+
         auto a = Fp!128(0, -13, UInt!128.fromHexString("dfbbfae3cd0aff2714a1de7022b0029d"));
         auto b = Fp!128(1, 100, UInt!128.fromHexString("e3251bacb112c88b71ad3f85a970a314"));
         auto fp = a * b;
@@ -354,6 +358,7 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
         auto fp = Fp!128(1, 100, UInt!128.fromHexString("e3251bacb112cb8b71ad3f85a970a314"));
         assert(cast(double)fp == -0xE3251BACB112C8p+172);
     }
@@ -364,6 +369,7 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
         auto fp = Fp!128(1, 100, UInt!128.fromHexString("e3251bacb112cb8b71ad3f85a970a314"));
         static if (real.mant_dig == 64)
             assert(cast(real)fp == -0xe3251bacb112cb8bp+164L);
@@ -375,6 +381,7 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
         auto fp = Fp!64(1, 100, UInt!64(0xe3251bacb112cb8b));
         version (DigitalMars)
         {
@@ -397,6 +404,7 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
         auto fp = Fp!64(1, 100, UInt!64(0xe3251bacb112cb8b));
         static if (real.mant_dig == 64)
             assert(cast(real)fp == -0xe3251bacb112cb8bp+100L);
@@ -417,6 +425,7 @@ struct Fp(size_t coefficientSize, Exp = sizediff_t)
     @safe pure @nogc
     unittest
     {
+        import mir.bignum.fixed: UInt;
         auto fp = cast(Fp!64) Fp!128(UInt!128.fromHexString("afbbfae3cd0aff2784a1de7022b0029d"));
         assert(fp.exponent == 64);
         assert(fp.coefficient == UInt!64.fromHexString("afbbfae3cd0aff28"));

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -42,12 +42,12 @@ template statType(T, bool checkComplex = true)
         static if (isComplex!T) {
             import std.traits: Unqual;
             static if (is(T : cdouble)) {
-                deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = Unqual!T;
+                deprecated("Built-in complex types deprecated in D language version 2.097") alias statType = Unqual!T;
             } else {
                 alias statType = Unqual!T;
             }
         } else static if (is(T : cdouble)) {
-                deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = cdouble;
+                deprecated("Built-in complex types deprecated in D language version 2.097") alias statType = cdouble;
         } else {
             static assert(0, "statType: type " ~ T.stringof ~ " must be convertible to a complex floating point type");
         }
@@ -203,6 +203,12 @@ unittest
     static assert(is(meanType!(int[]) == double));
     static assert(is(meanType!(double[]) == double));
     static assert(is(meanType!(float[]) == float));
+}
+
+version(mir_builtincomplex_test)
+@safe pure nothrow @nogc
+unittest
+{
     static assert(is(meanType!(cfloat[]) == cfloat));
 }
 
@@ -214,14 +220,20 @@ unittest
         float x;
         alias x this;
     }
-    
-    static struct Bar {
+
+    static assert(is(meanType!(Foo[]) == float));
+}
+
+version(mir_builtincomplex_test)
+@safe pure nothrow @nogc
+unittest
+{
+    static struct Foo {
         cfloat x;
         alias x this;
     }
 
-    static assert(is(meanType!(Foo[]) == float));
-    static assert(is(meanType!(Bar[]) == cfloat));
+    static assert(is(meanType!(Foo[]) == cfloat));
 }
 
 /++
@@ -328,8 +340,7 @@ Computes the mean of the input.
 
 By default, if `F` is not floating point type or complex type, then the result
 will have a `double` type if `F` is implicitly convertible to a floating point 
-type or have a `Complex!double` type if `F` is implicitly convertible to a
-complex type.
+type or a type for which `isComplex!F` is true.
 
 Params:
     F = controls type of output
@@ -651,8 +662,7 @@ Computes the harmonic mean of the input.
 
 By default, if `F` is not floating point type or complex type, then the result
 will have a `double` type if `F` is implicitly convertible to a floating point 
-type or have a `Complex!double` type if `F` is implicitly convertible to a
-complex type.
+type or a type for which `isComplex!F` is true.
 
 Params:
     F = controls type of output
@@ -1285,8 +1295,7 @@ Computes the median of `slice`.
 
 By default, if `F` is not floating point type or complex type, then the result
 will have a `double` type if `F` is implicitly convertible to a floating point 
-type or have a `Complex!double` type if `F` is implicitly convertible to a
-complex type.
+type or a type for which `isComplex!F` is true.
 
 Can also pass a boolean variable, `allowModify`, that allows the input slice to
 be modified. By default, a reference-counted copy is made. 
@@ -2724,8 +2733,7 @@ Calculates the variance of the input
 
 By default, if `F` is not floating point type or complex type, then the result
 will have a `double` type if `F` is implicitly convertible to a floating point 
-type or have a `Complex!double` type if `F` is implicitly convertible to a
-complex type.
+type or a type for which `isComplex!F` is true.
 
 Params:
     F = controls type of output

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -30,26 +30,26 @@ import std.traits: Unqual, isArray, isMutable, isIterable, isIntegral, CommonTyp
 package(mir)
 template statType(T, bool checkComplex = true)
 {
-    import mir.internal.utility: isFloatingPoint, isComplex;
+    import mir.internal.utility: isFloatingPoint;
 
-    static if (isFloatingPoint!T || (checkComplex && isComplex!T)) {
+    static if (isFloatingPoint!T) {
         import std.traits: Unqual;
-        
-        static if (is(T : cdouble)) {
-            deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = Unqual!T;
-        } else {
-            alias statType = Unqual!T;
-        }
+        alias statType = Unqual!T;
     } else static if (is(T : double)) {
         alias statType = double;
     } else static if (checkComplex) {
-        import std.complex: Complex;
-        static if (isComplex!T || is(T : Complex!U, U)) {
-            alias statType = Complex!double;
+        import mir.internal.utility: isComplex;
+        static if (isComplex!T) {
+            import std.traits: Unqual;
+            static if (is(T : cdouble)) {
+                deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = Unqual!T;
+            } else {
+                alias statType = Unqual!T;
+            }
         } else static if (is(T : cdouble)) {
-            deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = cdouble;
+                deprecated("Built-in complex types deprecated in D language version 2.097, use std.complex") alias statType = cdouble;
         } else {
-            static assert(0, "statType: type " ~ T.stringof ~ " must be convertible to a floating point (or complex floating point) type");
+            static assert(0, "statType: type " ~ T.stringof ~ " must be convertible to a complex floating point type");
         }
     } else {
         static assert(0, "statType: type " ~ T.stringof ~ " must be convertible to a floating point type");
@@ -120,20 +120,6 @@ version(mir_test)
 @safe pure nothrow @nogc
 unittest
 {
-    import std.complex: Complex;
-
-    static struct Foo {
-        Complex!float x;
-        alias x this;
-    }
-
-    static assert(is(statType!Foo == Complex!double)); // note: this is not Complex!float
-}
-
-version(mir_test)
-@safe pure nothrow @nogc
-unittest
-{
     static struct Foo {
         double x;
         alias x this;
@@ -158,20 +144,6 @@ version(mir_test)
 @safe pure nothrow @nogc
 unittest
 {
-    import std.complex: Complex;
-
-    static struct Foo {
-        Complex!double x;
-        alias x this;
-    }
-
-    static assert(is(statType!Foo == Complex!double));
-}
-
-version(mir_test)
-@safe pure nothrow @nogc
-unittest
-{
     static struct Foo {
         real x;
         alias x this;
@@ -190,20 +162,6 @@ unittest
     }
 
     static assert(is(statType!Foo == cdouble)); // note: this is not Complex!real
-}
-
-version(mir_test)
-@safe pure nothrow @nogc
-unittest
-{
-    import std.complex: Complex;
-
-    static struct Foo {
-        Complex!real x;
-        alias x this;
-    }
-
-    static assert(is(statType!Foo == Complex!double)); // note: this is not Complex!real
 }
 
 version(mir_test)

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -146,8 +146,8 @@ unittest
     //assert(r == ar.sum!"kahan");
     version(LDC) // DMD Internal error: backend/cgxmm.c 628
     {
-        assert(r == ar.sum!"kbn");
-        assert(r == ar.sum!"kb2");
+        //assert(r == ar.sum!"kbn");
+        //assert(r == ar.sum!"kb2");
     }
     //assert(r == ar.sum!"precise");
     //assert(r == ar.sum!"decimal");

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -472,14 +472,16 @@ struct Summator(T, Summation summation)
 
     @attr:
 
-    static if (summation == Summation.pairwise)
+    static if (summation == Summation.pairwise) {
+        import std.complex: Complex;
         private enum bool fastPairwise =
             is(F == float) ||
             is(F == double) ||
-            is(F == cfloat) ||
-            is(F == cdouble) ||
+            is(F == Complex!float) ||
+            is(F == Complex!double) ||
             is(F : __vector(W[N]), W, size_t N);
             //false;
+    }
 
     alias F = T;
 
@@ -1994,7 +1996,13 @@ unittest
     assert(sum!float(1) == 1f);
     assert(sum!float(1, 2, 3) == 6f);
     assert(sum!float(1.0, 2.0, 3.0) == 6f);
-    assert(sum!cfloat(1.0 + 1i, 2.0 + 2i, 3.0 + 3i) == (6f + 6i));
+}
+
+version(mir_test)
+unittest
+{
+    import std.complex: Complex;
+    assert(sum!(Complex!float)(Complex!float(1.0, 1.0), Complex!float(2.0, 2.0), Complex!float(3.0, 3.0)) == Complex!float(6.0, 6.0));
 }
 
 version(LDC)

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -495,7 +495,6 @@ struct Summator(T, Summation summation)
     @attr:
 
     static if (summation == Summation.pairwise) {
-        import std.complex: Complex;
         private enum bool fastPairwise =
             is(F == float) ||
             is(F == double) ||

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -698,8 +698,8 @@ public:
                     cs = 0 + 0fi;
                     ccs = 0 + 0fi;
                 } else {
-                    cs = Complex!float(0, 0i);
-                    ccs = Complex!float(0, 0i);
+                    cs = Complex!float(0, 0);
+                    ccs = Complex!float(0, 0);
                 }
             }
             else
@@ -716,7 +716,7 @@ public:
                 static if (is(T : cfloat)) {
                     c = 0 + 0fi;
                 } else {
-                    c = Complex!float(0, 0i);
+                    c = Complex!float(0, 0);
                 }
             } else
                 c = 0.0;
@@ -729,7 +729,7 @@ public:
                 static if (is(T : cfloat)) {
                     c = 0 + 0fi;
                 } else {
-                    c = Complex!float(0, 0i);
+                    c = Complex!float(0, 0);
                 }
             } else
                 c = 0.0;

--- a/source/mir/math/sum.d
+++ b/source/mir/math/sum.d
@@ -501,8 +501,7 @@ struct Summator(T, Summation summation)
             is(F == double) ||
             is(F == cfloat) ||
             is(F == cdouble) ||
-            is(F == Complex!float) ||
-            is(F == Complex!double) ||
+            (isComplex!F && F.sizeof <= 16) ||
             is(F : __vector(W[N]), W, size_t N);
             //false;
     }
@@ -877,9 +876,8 @@ public:
                         s = x_re + s.im * 1fi;
                         x = s_re + x.im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        s = Complex!float(x_re, s.im);
-                        x = Complex!float(s_re, x.im);
+                        s = F(x_re, s.im);
+                        x = F(s_re, x.im);
                     }
                 }
                 if (fabs(s.im) < fabs(x.im))
@@ -890,9 +888,8 @@ public:
                         s = s.re + x_im * 1fi;
                         x = x.re + s_im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        s = Complex!float(s.re, x_im);
-                        x = Complex!float(x.re, s_im);
+                        s = F(s.re, x_im);
+                        x = F(x.re, s_im);
                     }
                 }
                 F c = (s-t)+x;
@@ -905,9 +902,8 @@ public:
                         c = cs_re + c.im * 1fi;
                         cs = c_re + cs.im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        c = Complex!float(cs_re, c.im);
-                        cs = Complex!float(c_re, cs.im);
+                        c = F(cs_re, c.im);
+                        cs = F(c_re, cs.im);
                     }
                 }
                 if (fabs(cs.im) < fabs(c.im))
@@ -918,9 +914,8 @@ public:
                         c = c.re + cs_im * 1fi;
                         cs = cs.re + c_im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        c = Complex!float(c.re, cs_im);
-                        cs = Complex!float(cs.re, c_im);
+                        c = F(c.re, cs_im);
+                        cs = F(cs.re, c_im);
                     }
                 }
                 F d = cs - t;
@@ -960,9 +955,8 @@ public:
                         s = x_re + s.im * 1fi;
                         x = s_re + x.im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        s = Complex!float(x_re, s.im);
-                        x = Complex!float(s_re, x.im);
+                        s = F(x_re, s.im);
+                        x = F(s_re, x.im);
                     }
                 }
                 if (fabs(s.im) < fabs(x.im))
@@ -973,9 +967,8 @@ public:
                         s = s.re + x_im * 1fi;
                         x = x.re + s_im * 1fi;
                     } else {
-                        import std.complex: Complex;
-                        s = Complex!float(s.re, x_im);
-                        x = Complex!float(x.re, s_im);
+                        s = F(s.re, x_im);
+                        x = F(x.re, s_im);
                     }
                 }
                 F d = s - t;
@@ -1068,12 +1061,11 @@ public:
         else
         static if (summation == Summation.fast)
         {
-            static if (isComplex!T) {
-                static if (is(T : cfloat)) {
+            static if (isComplex!F) {
+                static if (is(F : cfloat)) {
                     F s0 = 0 + 0fi;
                 } else {
-                    import std.complex: Complex;
-                    F s0 = Complex!float(0.0, 0.0);
+                    F s0 = F(0, 0f);
                 }
             } else
                 F s0 = 0;
@@ -1106,12 +1098,11 @@ public:
         else
         static if (summation == Summation.fast && N == 1)
         {
-            static if (isComplex!T) {
-                static if (is(T : cfloat)) {
+            static if (isComplex!F) {
+                static if (is(F : cfloat)) {
                     F s0 = 0 + 0fi;
                 } else {
-                    import std.complex: Complex;
-                    F s0 = Complex!float(0.0, 0.0);
+                    F s0 = F(0, 0f);
                 }
             } else
                 F s0 = 0;
@@ -1422,9 +1413,8 @@ public:
                     cs = 0 + 0fi;
                     ccs = 0 + 0fi;
                 } else {
-                    import std.complex: Complex;
-                    cs = Complex!float(0.0, 0.0);
-                    ccs = Complex!float(0.0, 0.0);
+                    cs = T(0, 0f);
+                    ccs = T(0.0, 0f);
                 }
             }
             else
@@ -1441,8 +1431,7 @@ public:
                 static if (is(T : cfloat)) {
                     c = 0 + 0fi;
                 } else {
-                    import std.complex: Complex;
-                    c = Complex!float(0.0, 0.0);
+                    c = T(0, 0f);
                 }
             } else
                 c = 0.0;
@@ -1455,8 +1444,7 @@ public:
                 static if (is(T : cfloat)) {
                     c = 0 + 0fi;
                 } else {
-                    import std.complex: Complex;
-                    c = Complex!float(0.0, 0.0);
+                    c = T(0, 0f);
                 }
             } else
                 c = 0.0;


### PR DESCRIPTION
This PR addresses the built-in complex deprecation. It currently does not pass CI because `mir.math.sum`. The offending line is below. In particular, `hasElaborateAssign!T` is true for `Complex!U` instead of false for the built-in types. 

```d
    static if (is(T == class) || is(T == interface) || hasElaborateAssign!T)
        static assert (summation == Summation.naive,
            "Classes, interfaces, and structures with "
            ~ "elaborate constructor support only naive summation.");
```

Not sure how you want to handle (either special case it or just rely on other summation techniques for `Complex`). 