### PR TITLE
Add in support for hex literals using underscores

### DIFF
--- a/source/mir/bignum/fixed.d
+++ b/source/mir/bignum/fixed.d
@@ -197,10 +197,10 @@ struct UInt(size_t size)
     }
 
     ///
-    static UInt!size fromHexString(scope const(char)[] str)
+    static UInt!size fromHexString(bool allowUnderscores = false)(scope const(char)[] str)
     {
         typeof(return) ret;
-        if (ret.fromHexStringImpl(str))
+        if (ret.fromHexStringImpl!(char, allowUnderscores)(str))
             return ret;
         version(D_Exceptions)
         {
@@ -216,11 +216,11 @@ struct UInt(size_t size)
 
     /++
     +/
-    bool fromHexStringImpl(C)(scope const(C)[] str)
+    bool fromHexStringImpl(C, bool allowUnderscores = false)(scope const(C)[] str)
         @safe pure @nogc nothrow
         if (isSomeChar!C)
     {
-        return view.fromHexStringImpl(str);
+        return view.fromHexStringImpl!(C, allowUnderscores)(str);
     }
 
     /++

--- a/source/mir/bignum/integer.d
+++ b/source/mir/bignum/integer.d
@@ -366,11 +366,11 @@ struct BigInt(size_t maxSize64)
 
     /++
     +/
-    static BigInt fromHexString()(scope const(char)[] str)
+    static BigInt fromHexString(bool allowUnderscores = false)(scope const(char)[] str)
         @trusted pure
     {
         BigInt ret;
-        if (ret.fromHexStringImpl(str))
+        if (ret.fromHexStringImpl!(char, allowUnderscores)(str))
             return ret;
         version(D_Exceptions)
             throw hexStringException;
@@ -380,12 +380,12 @@ struct BigInt(size_t maxSize64)
 
     /++
     +/
-    bool fromHexStringImpl(C)(scope const(C)[] str)
+    bool fromHexStringImpl(C, bool allowUnderscores = false)(scope const(C)[] str)
         @safe pure @nogc nothrow
         if (isSomeChar!C)
     {
         auto work = BigIntView!size_t(data);
-        auto ret = work.fromHexStringImpl(str);
+        auto ret = work.fromHexStringImpl!(C, allowUnderscores)(str);
         if (ret)
         {
             length = cast(uint)work.unsigned.coefficients.length;

--- a/source/mir/bignum/low_level_view.d
+++ b/source/mir/bignum/low_level_view.d
@@ -698,30 +698,28 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     @safe pure
     unittest
     {
-        bool caught = false;
-        try {
-            auto view = BigUIntView!size_t.fromHexString!(char, true)("abcd_efab_cef_");
-        } catch (Exception e) {
-            caught = true;
+        // Check that invalid underscores in hex literals throw an error.
+        void expectThrow(const(char)[] input) {
+            bool caught = false;
+            try { 
+                auto view = BigUIntView!size_t.fromHexString!(char, true)(input);
+            } catch (Exception e) {
+                caught = true;
+            }
+
+            assert(caught);
         }
 
-        assert(caught);
-    }
-
-    static if (W.sizeof == size_t.sizeof && endian == TargetEndian)
-    ///
-    version(mir_bignum_test)
-    @safe pure
-    unittest
-    {
-        bool caught = false;
-        try {
-            auto view = BigUIntView!size_t.fromHexString!(char, true)("abcd__efab__cef");
-        } catch (Exception e) {
-            caught = true;
-        }
-
-        assert(caught);
+        expectThrow("abcd_efab_cef_");
+        expectThrow("abcd__efab__cef");
+        expectThrow("_abcd_efab_cdef");
+        expectThrow("_abcd_efab_cdef_");
+        expectThrow("_abcd_efab_cdef__");
+        expectThrow("__abcd_efab_cdef");
+        expectThrow("__abcd_efab_cdef_");
+        expectThrow("__abcd_efab_cdef__");
+        expectThrow("__abcd__efab_cdef__");
+        expectThrow("__abcd__efab__cdef__");
     }
 
     static if (isMutable!W && W.sizeof >= 4)


### PR DESCRIPTION
Adds in support for hex literals with underscores for better readability. Should not change the existing behavior, but added several unit-tests to verify that the underscore literals are equivalent to non-underscore literals.

Note: in `static BigUIntView fromHexString()`, we actually over-allocate for the amount of coefficients that we need
https://github.com/libmir/mir-algorithm/blob/085212a0df9962d13ac626778405bd71c1e2ade9/source/mir/bignum/low_level_view.d#L572

This is sliced down to the amount that was actually taken here (where j represents the number of non-underscore characters)
https://github.com/libmir/mir-algorithm/blob/085212a0df9962d13ac626778405bd71c1e2ade9/source/mir/bignum/low_level_view.d#L680

This does increase the initial memory footprint (especially as the input string gets longer), but I haven't been able to think of a good way to get around this while keeping fromHexStringImpl @nogc. Ideally, I want to avoid iterating through the whole string twice, but that seems like the only solution that seems feasible to me.