### PR TITLE
Add GitHub Actions to replace Travis-CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+    # allow this workflow to be triggered manually
+
+jobs:
+  builder:
+    name: 'Build and test on ${{ matrix.arch }}-${{ matrix.os }}/${{ matrix.dc }}'
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ contains(matrix.dc, 'master') || contains(matrix.dc, 'beta') || matrix.dc == 'gdc' }}
+    env:
+      ARCH: ${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dc: [ldc-latest, ldc-beta, dmd-latest, dmd-master, dmd-beta, gdc]
+        os: [ubuntu-latest]
+        arch: [x86, x86_64]
+        include:
+          - dc: ldc-latest
+            os: macos-latest
+            arch: x86_64
+          - dc: dmd-latest
+            os: macos-latest
+            arch: x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dlang-community/setup-dlang@v1.1.0
+        if: matrix.dc != 'gdc'
+        with:
+          compiler: ${{ matrix.dc }}
+      - uses: dlang-community/setup-dlang@v1.1.0
+        name: 'Work around Ubuntu-packaged dub bug'
+        if: matrix.dc == 'gdc'
+        with:
+          compiler: dmd-latest
+      - name: Install GDC
+        if: matrix.dc == 'gdc'
+        run: |
+          sudo apt-get install gdc
+          echo "DC=gdc" >> $GITHUB_ENV
+      - name: Install multi-lib for 32-bit systems
+        if: matrix.arch == 'x86'
+        run: sudo apt-get install gcc-multilib
+      - id: build
+        name: Test building
+        run: bash -e test_travis.sh
+      - id: coverage
+        name: Upload coverage data
+        run: bash <(curl -s https://codecov.io/bash)
+    
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
   builder:
     name: 'Build and test on ${{ matrix.arch }}-${{ matrix.os }}/${{ matrix.dc }}'
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ contains(matrix.dc, 'master') || contains(matrix.dc, 'beta') || matrix.dc == 'gdc' }}
+    continue-on-error: ${{ contains(matrix.dc, 'master') || contains(matrix.dc, 'beta') }}
     env:
       ARCH: ${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
-        dc: [ldc-latest, ldc-beta, dmd-latest, dmd-master, dmd-beta, gdc]
+        dc: [ldc-latest, ldc-beta, dmd-latest, dmd-master, dmd-beta]
         os: [ubuntu-latest]
         arch: [x86, x86_64]
         include:
@@ -33,19 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dlang-community/setup-dlang@v1.1.0
-        if: matrix.dc != 'gdc'
         with:
           compiler: ${{ matrix.dc }}
-      - uses: dlang-community/setup-dlang@v1.1.0
-        name: 'Work around Ubuntu-packaged dub bug'
-        if: matrix.dc == 'gdc'
-        with:
-          compiler: dmd-latest
-      - name: Install GDC
-        if: matrix.dc == 'gdc'
-        run: |
-          sudo apt-get install gdc
-          echo "DC=gdc" >> $GITHUB_ENV
       - name: Install multi-lib for 32-bit systems
         if: matrix.arch == 'x86'
         run: sudo apt-get install gcc-multilib

--- a/test_travis.sh
+++ b/test_travis.sh
@@ -4,8 +4,12 @@ then
   docker run --rm --privileged multiarch/qemu-user-static:register --reset
   docker build -t ion-arm64 . -f Dockerfile.aarch64
 else
+  echo $DC
   echo $ARCH
-  dub test --arch=$ARCH --build=unittest-dip1000
+  if [ "$DC" != "gdc" ] 
+  then
+    dub test --arch=$ARCH --build=unittest-dip1000
+  fi
   dub test --arch=$ARCH --build=unittest-cov
   # if [ \( "$DC" = "ldc2" \) -o \( "$DC" = "ldmd2" \) ]
   # then


### PR DESCRIPTION
Adds in GitHub Actions support to replace the now-disabled Travis-CI flow. 

Does not include aarch64 support -- that is coming soon, as we can run the tests natively on CircleCI.