### PR TITLE
Use const parameters in mir.format to reduce template bloat

### DIFF
--- a/source/mir/format.d
+++ b/source/mir/format.d
@@ -59,7 +59,7 @@ unittest
 }
 
 /// Concatenated string results
-string text(string separator = "", A...)(auto ref A args)
+string text(string separator = "", A...)(auto ref const(A) args)
         if (A.length > 0)
 {
     static if (A.length == 1)
@@ -406,7 +406,7 @@ ref W printEscaped(C, EscapeFormat escapeFormat = EscapeFormat.ion, W)(scope ret
 @safe pure nothrow @nogc
 version (mir_test) unittest
 {
- 
+
     import mir.format: stringBuf;
     stringBuf w;
     assert(w.printEscaped("Hi \a\v\0\f\t\b \\\r\n" ~ `"@nogc"`).data == `Hi \a\v\0\f\t\b \\\r\n\"@nogc\"`);

--- a/source/mir/format.d
+++ b/source/mir/format.d
@@ -59,8 +59,8 @@ unittest
 }
 
 /// Concatenated string results
-string text(string separator = "", A...)(auto ref const(Args) args)
-        if (Args.length > 0)
+string text(string separator = "", Args...)(auto ref const(Args) args)
+    if (Args.length > 0)
 {
     static if (Args.length == 1)
     {


### PR DESCRIPTION
The important changes are the qualifications of the parameters to the `text` and `print` overloads which in essence strips off either `const` or `immutable` qualifier from the type(s) `A`. In calls such as

```d
text(int.init)
text(const(int).init)
text(immutable(int).init)
...
```

all result in the same template instance of `text` potentially saving time and space requirements on compilation and binary sizes.