### PR TITLE
Revert "Use const parameters in mir.format to reduce template bloat"

### DIFF
--- a/source/mir/format.d
+++ b/source/mir/format.d
@@ -60,7 +60,7 @@ unittest
 }
 
 /// Concatenated string results
-string text(string separator = "", Args...)(auto ref const(Args) args)
+string text(string separator = "", Args...)(auto ref Args args)
     if (Args.length > 0)
 {
     static if (Args.length == 1)

--- a/source/mir/format.d
+++ b/source/mir/format.d
@@ -88,7 +88,8 @@ string text(string separator = "", Args...)(auto ref Args args)
 ///
 @safe pure nothrow unittest
 {
-    assert(text("str ", true, " ", 100, " ", 124.1) == "str true 100 124.1", text("str ", true, " ", 100, " ", 124.1));
+    const i = 100;
+    assert(text("str ", true, " ", i, " ", 124.1) == "str true 100 124.1", text("str ", true, " ", 100, " ", 124.1));
     assert(text!" "("str", true, 100, 124.1) == "str true 100 124.1");
 }
 


### PR DESCRIPTION
Reverts libmir/mir-algorithm#359