### PR TITLE
Add fixes to both the Decimal and DecimalView impls to allow exponents to follow dots

### DIFF
--- a/source/mir/bignum/low_level_view.d
+++ b/source/mir/bignum/low_level_view.d
@@ -2489,6 +2489,7 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
         scope @trusted pure @nogc nothrow
         if (isSomeChar!C)
     {
+        debug import std.stdio;
         import mir.utility: _expect;
 
         version(LDC)
@@ -2538,6 +2539,9 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
             bool recentUnderscore;
         }
 
+        // Was there a recent character within the set: ['.', 'e', 'E', 'd', 'D']?
+        bool recentModifier;
+
         static if (!allowLeadingZeros)
         {
             if (d == 0)
@@ -2566,6 +2570,7 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                     return false;
                 key = DecimalExponentKey.dot;
                 dot = true;
+                recentModifier = true;
                 goto F;
             }
         }
@@ -2591,6 +2596,7 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                 {
                     recentUnderscore = false;
                 }
+                recentModifier = false;
                 v *= 10;
         S:
                 t *= 10;
@@ -2622,35 +2628,43 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                         coefficient = work.mostSignificant == 0 ? coefficient.init : work;
                         static if (allowUnderscores)
                         {
-                            return !recentUnderscore;
+                            // If we have no characters, then we should return true IF
+                            // the last character was NOT a underscore OR a modifier
+                            return !recentUnderscore && !recentModifier;
                         }
                         else
                         {
-                            return true;
+                            // If we don't allow underscores, and we have no characters,
+                            // then we should return true IF the character was NOT a modifier.
+                            return !recentModifier;
                         }
                     }
                 }
 
                 continue;
             }
-            static if (allowUnderscores)
-            {
-                if (recentUnderscore)
-                    return false;
-            }
+
             switch (d)
             {
                 case DecimalExponentKey.dot:
+                    // The dot modifier CANNOT be preceded by any modifiers. 
+                    if (recentModifier || key != DecimalExponentKey.none)
+                        return false;
+
+                    static if (allowUnderscores)
+                    {
+                        // If we allow underscores, it also CANNOT be preceded by any underscores.
+                        if (recentUnderscore)
+                            return false;
+                    }
+
                     key = DecimalExponentKey.dot;
                     if (_expect(dot, false))
                         break;
                     dot = true;
                     if (str.length)
                     {
-                        static if (allowUnderscores)
-                        {
-                            recentUnderscore = true;
-                        }
+                        recentModifier = true;
                         continue;
                     }
                     static if (allowDotOnBounds)
@@ -2672,9 +2686,14 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                     case DecimalExponentKey.e:
                     case DecimalExponentKey.E:
                         import mir.parse: parse;
+                        // We don't really care if the e/E/d/D modifiers are preceded by a modifier,
+                        // so as long as they are a dot or a regular number.
+                        if (key != DecimalExponentKey.dot || key != DecimalExponentKey.none)
+                            return false;
                         key = cast(DecimalExponentKey)d;
                         if (parse(str, exponent) && str.length == 0)
                         {
+                            recentModifier = false;
                             if (t != 1)
                                 goto L;
                             goto M;
@@ -2684,6 +2703,10 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                 static if (allowUnderscores)
                 {
                     case '_' - '0':
+                        // A underscore cannot be preceded by an underscore or a modifier.
+                        if (recentUnderscore || recentModifier)
+                            return false;
+                        
                         recentUnderscore = true;
                         if (str.length)
                             continue;
@@ -2693,6 +2716,7 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
             }
             break;
         }
+
         return false;
 
         static if (allowSpecialValues)
@@ -2893,6 +2917,27 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
         if (sign)
             ret = -ret;
         return ret;
+    }
+}
+
+/// Test that DecimalView can handle a dot followed by an exponent
+version(mir_bignum_test)
+unittest
+{
+    {
+        DecimalView!ulong view = void;
+        DecimalExponentKey exponentKey;
+
+        assert(view.fromStringImpl!(char,
+            true /* allowSpecialValues */,
+            true /* allowDotOnBounds */,
+            true /* allowDExponent */,
+            true /* allowStartingPlus */,
+            true /* allowUnderscores */,
+            true /* allowLeadingZeros */,
+            true /* allowExponent */,
+            true /* checkEmpty */)
+        ("123456.e0", exponentKey));
     }
 }
 

--- a/source/mir/bignum/low_level_view.d
+++ b/source/mir/bignum/low_level_view.d
@@ -2653,7 +2653,8 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
 
                     static if (allowUnderscores)
                     {
-                        // If we allow underscores, it also CANNOT be preceded by any underscores.
+                        // If we allow underscores, the dot also CANNOT be preceded by any underscores.
+                        // It must be preceded by a number.
                         if (recentUnderscore)
                             return false;
                     }
@@ -2688,7 +2689,7 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
                         import mir.parse: parse;
                         // We don't really care if the e/E/d/D modifiers are preceded by a modifier,
                         // so as long as they are a dot or a regular number.
-                        if (key != DecimalExponentKey.dot || key != DecimalExponentKey.none)
+                        if (key != DecimalExponentKey.dot && key != DecimalExponentKey.none)
                             return false;
                         key = cast(DecimalExponentKey)d;
                         if (parse(str, exponent) && str.length == 0)
@@ -2917,27 +2918,6 @@ struct DecimalView(W, WordEndian endian = TargetEndian, Exp = sizediff_t)
         if (sign)
             ret = -ret;
         return ret;
-    }
-}
-
-/// Test that DecimalView can handle a dot followed by an exponent
-version(mir_bignum_test)
-unittest
-{
-    {
-        DecimalView!ulong view = void;
-        DecimalExponentKey exponentKey;
-
-        assert(view.fromStringImpl!(char,
-            true /* allowSpecialValues */,
-            true /* allowDotOnBounds */,
-            true /* allowDExponent */,
-            true /* allowStartingPlus */,
-            true /* allowUnderscores */,
-            true /* allowLeadingZeros */,
-            true /* allowExponent */,
-            true /* checkEmpty */)
-        ("123456.e0", exponentKey));
     }
 }
 


### PR DESCRIPTION
This PR adds support for decimal literals specified in #365. Examples of these literals are:
```
2000000000.e0 
4000000000.e0 
5000000000.e0 
-2000000000.e0 
-4000000000.e0 
-5000000000.e0
```

This is a relatively trivial fix, and shouldn't significantly impact the existing parsing code. Let me know if this needs any further work.