### PR TITLE
Add documentation comments for public imports

### DIFF
--- a/source/mir/algebraic_alias/ion.d
+++ b/source/mir/algebraic_alias/ion.d
@@ -12,9 +12,13 @@ Macros:
 module mir.algebraic_alias.ion;
 
 import mir.algebraic: TaggedVariant, This;
+///
 public import mir.annotated: Annotated;
+///
 public import mir.lob: Clob, Blob;
+///
 public import mir.string_map: StringMap;
+///
 public import mir.timestamp: Timestamp;
 
 

--- a/source/mir/algebraic_alias/json.d
+++ b/source/mir/algebraic_alias/json.d
@@ -12,6 +12,7 @@ Macros:
 module mir.algebraic_alias.json;
 
 import mir.algebraic: TaggedVariant, This;
+///
 public import mir.string_map: StringMap;
 
 /++

--- a/source/mir/bignum/decimal.d
+++ b/source/mir/bignum/decimal.d
@@ -8,6 +8,7 @@ module mir.bignum.decimal;
 
 import mir.serde: serdeProxy, serdeScoped;
 import std.traits: isSomeChar;
+///
 public import mir.bignum.low_level_view: DecimalExponentKey;
 import mir.bignum.low_level_view: ceilLog10Exp2;
 

--- a/source/mir/interpolate/constant.d
+++ b/source/mir/interpolate/constant.d
@@ -49,6 +49,8 @@ import mir.rc.array;
 import mir.utility: min, max;
 import std.meta: AliasSeq, staticMap;
 import std.traits;
+
+///
 public import mir.interpolate: atInterval;
 
 /++

--- a/source/mir/interpolate/generic.d
+++ b/source/mir/interpolate/generic.d
@@ -71,6 +71,8 @@ import mir.rc.array;
 import mir.utility: min, max;
 import std.meta: AliasSeq, staticMap;
 import std.traits;
+
+///
 public import mir.interpolate: atInterval;
 
 /++

--- a/source/mir/interpolate/linear.d
+++ b/source/mir/interpolate/linear.d
@@ -24,6 +24,8 @@ import mir.rc.array;
 import mir.utility: min, max;
 import std.meta: AliasSeq, staticMap;
 import std.traits;
+
+///
 public import mir.interpolate: atInterval;
 
 enum  msg_min =  "linear interpolant: minimal allowed length for the grid equals 2.";

--- a/source/mir/interpolate/polynomial.d
+++ b/source/mir/interpolate/polynomial.d
@@ -13,6 +13,7 @@ T2=$(TR $(TDNW $(LREF $1)) $(TD $+))
 +/
 module mir.interpolate.polynomial;
 
+///
 public import mir.interpolate: atInterval;
 import core.lifetime: move;
 import mir.functional: RefTuple;

--- a/source/mir/interpolate/spline.d
+++ b/source/mir/interpolate/spline.d
@@ -26,6 +26,8 @@ import mir.rc.array;
 import mir.utility: min, max;
 import std.meta: AliasSeq, staticMap;
 import std.traits: Unqual;
+
+///
 public import mir.interpolate: atInterval;
 
 static immutable msg_min =  "spline interpolant: minimal allowed length for the grid equals 2.";

--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -25,6 +25,8 @@ import mir.math.sum;
 import mir.ndslice.slice: Slice, SliceKind, hasAsSlice;
 import mir.primitives;
 import std.traits: Unqual, isArray, isMutable, isIterable, isIntegral, CommonType;
+
+///
 public import mir.math.sum: Summation;
 
 ///

--- a/source/mir/ndslice/internal.d
+++ b/source/mir/ndslice/internal.d
@@ -18,6 +18,7 @@ template ConstIfPointer(T)
         alias ConstIfPointer = T;
 }
 
+///
 public import mir.utility: _expect;
 
 struct RightOp(string op, T)

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -45,6 +45,7 @@ import mir.utility;
 import std.meta;
 import std.traits;
 
+///
 public import mir.primitives: DeepElementType;
 
 /++

--- a/source/mir/rc/package.d
+++ b/source/mir/rc/package.d
@@ -20,8 +20,11 @@ See_also: $(MREF mir,ndslice).
 +/
 module mir.rc;
 
+///
 public import mir.rc.array;
+///
 public import mir.rc.ptr;
+///
 public import mir.rc.slim_ptr;
 
 import mir.ndslice.slice;

--- a/source/mir/series.d
+++ b/source/mir/series.d
@@ -20,7 +20,9 @@ import mir.ndslice.sorting: transitionIndex;
 import mir.qualifier;
 import mir.serde: serdeIgnore, serdeFields;
 import std.traits;
+///
 public import mir.ndslice.slice;
+///
 public import mir.ndslice.sorting: sort;
 
 /++


### PR DESCRIPTION
Based on issue #41  left off the documentation imports for the ndslice package.d since the documentation in there already makes it a bit obvious that they are available. 