### PR TITLE
Fix DIP1000 related deprecation warnings and errors in v2.100.0-rc.1

### DIFF
--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -3871,7 +3871,7 @@ struct Uniq(alias pred, Range)
             while (!_input.empty && pred(last, _input.back));
         }
 
-        auto ref back() scope return @property
+        auto ref back() return scope @property
         {
             assert(!empty, "Attempting to fetch the back of an empty uniq.");
             return _input.back;
@@ -3891,7 +3891,7 @@ struct Uniq(alias pred, Range)
 
     static if (isForwardRange!Range)
     {
-        @property typeof(this) save() scope return
+        @property typeof(this) save() return scope
         {
             return typeof(this)(_input.save);
         }
@@ -4028,7 +4028,7 @@ struct Filter(alias pred, Range)
     import std.range.primitives: isForwardRange;
     static if (isForwardRange!Range)
     {
-        @property typeof(this) save() scope return
+        @property typeof(this) save() return scope
         {
             return typeof(this)(_input.save);
         }

--- a/source/mir/appender.d
+++ b/source/mir/appender.d
@@ -214,7 +214,7 @@ struct ScopedBuffer(T, size_t bytes = 4096)
     }
 
     ///
-    inout(T)[] data() inout @property @safe scope
+    inout(T)[] data() inout @property @safe scope return
     {
         return _buffer.length ? _buffer[0 .. _currentLength] : _scopeBuffer[0 .. _currentLength];
     }

--- a/source/mir/bignum/low_level_view.d
+++ b/source/mir/bignum/low_level_view.d
@@ -414,7 +414,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     static if (endian == TargetEndian)
     ///
     @trusted pure nothrow @nogc
-    BigUIntView!V opCast(T : BigUIntView!V, V)() scope return
+    BigUIntView!V opCast(T : BigUIntView!V, V)() return scope
         if (V.sizeof <= W.sizeof)
     {
         return typeof(return)(cast(V[])this.coefficients);
@@ -422,7 +422,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     ///
     BigUIntView!(const W, endian) lightConst()()
-        const @safe pure nothrow @nogc @property scope return
+        const @safe pure nothrow @nogc @property return scope
     {
         return typeof(return)(coefficients);
     }
@@ -451,7 +451,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     /++
     +/
-    ref inout(W) mostSignificant() inout @property scope return
+    ref inout(W) mostSignificant() inout @property return scope
     {
         static if (endian == WordEndian.big)
             return coefficients[0];
@@ -461,7 +461,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     /++
     +/
-    ref inout(W) leastSignificant() inout @property scope return
+    ref inout(W) leastSignificant() inout @property return scope
     {
         static if (endian == WordEndian.little)
             return coefficients[0];
@@ -491,7 +491,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     /++
     +/
-    BigUIntView topMostSignificantPart(size_t length) scope return
+    BigUIntView topMostSignificantPart(size_t length) return scope
     {
         static if (endian == WordEndian.big)
             return BigUIntView(coefficients[0 .. length]);
@@ -501,7 +501,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     /++
     +/
-    BigUIntView topLeastSignificantPart(size_t length) scope return
+    BigUIntView topLeastSignificantPart(size_t length) return scope
     {
         static if (endian == WordEndian.little)
             return BigUIntView(coefficients[0 .. length]);
@@ -1128,7 +1128,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     /++
     Returns: the same intger view with inversed sign
     +/
-    BigIntView!(W, endian) opUnary(string op : "-")() scope return
+    BigIntView!(W, endian) opUnary(string op : "-")() return scope
     {
         return typeof(return)(this, true);
     }
@@ -1160,7 +1160,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     Returns: a slice of coefficients starting from the least significant.
     +/
     auto leastSignificantFirst()
-        @safe pure nothrow @nogc @property scope return
+        @safe pure nothrow @nogc @property return scope
     {
         import mir.ndslice.slice: sliced;
         static if (endian == WordEndian.little)
@@ -1176,7 +1176,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     ///
     auto leastSignificantFirst()
-        const @safe pure nothrow @nogc @property scope return
+        const @safe pure nothrow @nogc @property return scope
     {
         import mir.ndslice.slice: sliced;
         static if (endian == WordEndian.little)
@@ -1194,7 +1194,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     Returns: a slice of coefficients starting from the most significant.
     +/
     auto mostSignificantFirst()
-        @safe pure nothrow @nogc @property scope return
+        @safe pure nothrow @nogc @property return scope
     {
         import mir.ndslice.slice: sliced;
         static if (endian == WordEndian.big)
@@ -1210,7 +1210,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
 
     ///
     auto mostSignificantFirst()
-        const @safe pure nothrow @nogc @property scope return
+        const @safe pure nothrow @nogc @property return scope
     {
         import mir.ndslice.slice: sliced;
         static if (endian == WordEndian.big)
@@ -1227,7 +1227,7 @@ struct BigUIntView(W, WordEndian endian = TargetEndian)
     /++
     Strips most significant zero coefficients.
     +/
-    BigUIntView normalized() scope return
+    BigUIntView normalized() return scope
     {
         auto number = this;
         if (number.coefficients.length) do
@@ -1549,7 +1549,7 @@ struct BigIntView(W, WordEndian endian = TargetEndian)
     bool sign;
 
     ///
-    inout(W)[] coefficients() inout @property scope return
+    inout(W)[] coefficients() inout @property return scope
     {
         return unsigned.coefficients;
     }
@@ -1912,14 +1912,14 @@ struct BigIntView(W, WordEndian endian = TargetEndian)
 
     static if (endian == TargetEndian)
     ///
-    BigIntView!V opCast(T : BigIntView!V, V)() scope return
+    BigIntView!V opCast(T : BigIntView!V, V)() return scope
         if (V.sizeof <= W.sizeof)
     {
         return typeof(return)(this.unsigned.opCast!(BigUIntView!V), sign);
     }
 
     ///
-    BigIntView!(const W, endian) lightConst()() scope return
+    BigIntView!(const W, endian) lightConst()() return scope
         const @safe pure nothrow @nogc @property
     {
         return typeof(return)(unsigned.lightConst, sign);

--- a/source/mir/container/binaryheap.d
+++ b/source/mir/container/binaryheap.d
@@ -180,7 +180,7 @@ public:
     Returns a _front of the heap, which is the largest element
     according to `less`.
     +/
-    @property auto ref ElementType!Store front() scope return
+    @property auto ref ElementType!Store front() return scope
     {
         assert(!empty, "Cannot call front on an empty heap.");
         return _store.front;

--- a/source/mir/interpolate/constant.d
+++ b/source/mir/interpolate/constant.d
@@ -130,14 +130,14 @@ extern(D):
     Constant lightConst()() const @property { return *cast(Constant*)&this; }
 
     ///
-    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() scope return const @property
+    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() return scope const @property
         if (dimension < N)
     {
         return _grid[dimension].lightConst.sliced(_data._lengths[dimension]);
     }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension < N)
     {
         return _grid[dimension]._iterator[0 .. _data._lengths[dimension]];

--- a/source/mir/interpolate/generic.d
+++ b/source/mir/interpolate/generic.d
@@ -149,14 +149,14 @@ extern(D):
     Generic lightConst()() const @property { return *cast(Generic*)&this; }
 
     ///
-    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() scope return const @property
+    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() return scope const @property
         if (dimension == 0)
     {
         return _grid.lightConst.sliced(_data._lengths[0]);
     }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension == 0)
     {
         return _grid._iterator[0 .. _data._lengths[0]];

--- a/source/mir/interpolate/linear.d
+++ b/source/mir/interpolate/linear.d
@@ -236,14 +236,14 @@ struct Linear(F, size_t N = 1, X = F)
     Linear lightConst()() const @property { return *cast(Linear*)&this; }
 
     ///
-    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() scope return const @property
+    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() return scope const @property
         if (dimension < N)
     {
         return _grid[dimension].lightConst.sliced(_data._lengths[dimension]);
     }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension < N)
     {
         return _grid[dimension]._iterator[0 .. _data._lengths[dimension]];
@@ -478,7 +478,7 @@ struct MetaLinear(T, X)
     MetaLinear lightConst()() const @property { return *cast(MetaLinear*)&this; }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension == 0)
     {
         return grid[];

--- a/source/mir/interpolate/polynomial.d
+++ b/source/mir/interpolate/polynomial.d
@@ -161,7 +161,7 @@ scope const:
         ///
         ref const(Slice!(RCI!(immutable X))) grid() { return _grid; }
         ///
-        immutable(X)[] gridScopeView() scope return const @property @trusted { return _grid.lightScope.field; }
+        immutable(X)[] gridScopeView() return scope const @property @trusted { return _grid.lightScope.field; }
         ///
         ref const(RCArray!(immutable T)) inversedBarycentricWeights() { return _inversedBarycentricWeights; }
         ///

--- a/source/mir/interpolate/spline.d
+++ b/source/mir/interpolate/spline.d
@@ -846,14 +846,14 @@ struct Spline(F, size_t N = 1, X = F)
     Spline lightImmutable() immutable @property { return *cast(Spline*)&this; }
 
     ///
-    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() scope return const @property
+    Slice!(RCI!(immutable X)) grid(size_t dimension = 0)() return scope const @property
         if (dimension < N)
     {
         return _grid[dimension].lightConst.sliced(_data._lengths[dimension]);
     }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension < N)
     {
         return _grid[dimension]._iterator[0 .. _data._lengths[dimension]];
@@ -1668,7 +1668,7 @@ struct MetaSpline(T, X)
     MetaLinear lightConst()() const @property { return *cast(MetaLinear*)&this; }
 
     ///
-    immutable(X)[] gridScopeView(size_t dimension = 0)() scope return const @property @trusted
+    immutable(X)[] gridScopeView(size_t dimension = 0)() return scope const @property @trusted
         if (dimension == 0)
     {
         return splines[0].gridScopeView;

--- a/source/mir/ndslice/iterator.d
+++ b/source/mir/ndslice/iterator.d
@@ -1958,7 +1958,7 @@ struct FlattenedIterator(Iterator, size_t N, SliceKind kind)
 
     static if (isMutable!(_slice.DeepElement) && !_slice.hasAccessByRef)
     ///
-    auto ref opIndexAssign(E)(scope ref E elem, size_t index) scope return
+    auto ref opIndexAssign(E)(scope ref E elem, size_t index) return scope
     {
         return _slice._iterator[getShift(index)] = elem;
     }

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -945,7 +945,7 @@ public:
     Returns: View with stripped out reference counted context.
     The lifetime of the result mustn't be longer then the lifetime of the original slice.
     +/
-    auto lightScope()() scope return @property
+    auto lightScope()() return scope @property
     {
         auto ret = Slice!(LightScopeOf!Iterator, N, kind, staticMap!(LightScopeOf, Labels))
             (_structure, .lightScope(_iterator));
@@ -955,7 +955,7 @@ public:
     }
 
     /// ditto
-    auto lightScope()() scope const return @property
+    auto lightScope()() return const scope @property
     {
         auto ret = Slice!(LightConstOf!(LightScopeOf!Iterator), N, kind, staticMap!(LightConstOfLightScopeOf, Labels))
             (_structure, .lightScope(_iterator));
@@ -965,7 +965,7 @@ public:
     }
 
     /// ditto
-    auto lightScope()() scope immutable return @property
+    auto lightScope()() return immutable scope @property
     {
         auto ret =  Slice!(LightImmutableOf!(LightScopeOf!Iterator), N, kind, staticMap!(LightImmutableOfLightConstOf(Labels)))
             (_structure, .lightScope(_iterator));
@@ -975,7 +975,7 @@ public:
     }
 
     /// Returns: Mutable slice over immutable data.
-    Slice!(LightImmutableOf!Iterator, N, kind, staticMap!(LightImmutableOf, Labels)) lightImmutable()() scope return immutable @property
+    Slice!(LightImmutableOf!Iterator, N, kind, staticMap!(LightImmutableOf, Labels)) lightImmutable()() return scope immutable @property
     {
         auto ret = typeof(return)(_structure, .lightImmutable(_iterator));
         foreach(i; Iota!L)
@@ -984,7 +984,7 @@ public:
     }
 
     /// Returns: Mutable slice over const data.
-    Slice!(LightConstOf!Iterator, N, kind, staticMap!(LightConstOf, Labels)) lightConst()() scope return const @property @trusted
+    Slice!(LightConstOf!Iterator, N, kind, staticMap!(LightConstOf, Labels)) lightConst()() return scope const @property @trusted
     {
         auto ret = typeof(return)(_structure, .lightConst(_iterator));
         foreach(i; Iota!L)
@@ -993,7 +993,7 @@ public:
     }
 
     /// ditto
-    Slice!(LightImmutableOf!Iterator, N, kind, staticMap!(LightImmutableOf, Labels)) lightConst()() scope return immutable @property
+    Slice!(LightImmutableOf!Iterator, N, kind, staticMap!(LightImmutableOf, Labels)) lightConst()() return scope immutable @property
     {
         return this.lightImmutable;
     }
@@ -1070,14 +1070,14 @@ public:
         /++
         Cast to const and immutable slices in case of underlying range is a pointer.
         +/
-        auto toImmutable()() scope return immutable @trusted pure nothrow @nogc
+        auto toImmutable()() return scope immutable @trusted pure nothrow @nogc
         {
             return Slice!(ImmutableOfUnqualOfPointerTarget!Iterator, N, kind, staticMap!(ImmutableOfUnqualOfPointerTarget, Labels))
                 (_structure, _iterator, _labels);
         }
 
         /// ditto
-        auto toConst()() scope return const @trusted pure nothrow @nogc
+        auto toConst()() return scope const @trusted pure nothrow @nogc
         {
             version(LDC) pragma(inline, true);
             return Slice!(ConstOfUnqualOfPointerTarget!Iterator, N, kind, staticMap!(ConstOfUnqualOfPointerTarget, Labels))
@@ -1162,7 +1162,7 @@ public:
     Returns:
         Iterator (pointer) to the $(LREF .Slice.first) element.
     +/
-    auto iterator()() inout scope return @property
+    auto iterator()() inout return scope @property
     {
         return _iterator;
     }
@@ -1176,7 +1176,7 @@ public:
     {
         import mir.rc.array: mir_rci;
         static if (kind == Contiguous && is(Iterator : mir_rci!ET, ET))
-        auto ptr() scope return inout @property
+        auto ptr() return scope inout @property
         {
             return _iterator._iterator;
         }
@@ -1189,7 +1189,7 @@ public:
     Constraints:
         Field is defined only for contiguous slices.
     +/
-    auto field()() scope return @trusted @property
+    auto field()() return scope @trusted @property
     {
         static assert(kind == Contiguous, "Slice.field is defined only for contiguous slices. Slice kind is " ~ kind.stringof);
         static if (is(typeof(_iterator[size_t(0) .. elementCount])))
@@ -1204,13 +1204,13 @@ public:
     }
 
     /// ditto
-    auto field()() scope const return @trusted @property
+    auto field()() return const scope @trusted @property
     {
         return this.lightConst.field;
     }
 
     /// ditto
-    auto field()() scope immutable return @trusted @property
+    auto field()() return immutable scope @trusted @property
     {
         return this.lightImmutable.field;
     }
@@ -1482,7 +1482,7 @@ public:
     static if (N == 1)
     {
         ///ditto
-        auto ref front(size_t dimension = 0)() scope return @trusted @property
+        auto ref front(size_t dimension = 0)() return scope @trusted @property
             if (dimension == 0)
         {
             assert(!empty!dimension);
@@ -1490,7 +1490,7 @@ public:
         }
 
         ///ditto
-        auto ref front(size_t dimension = 0)() scope return @trusted @property const
+        auto ref front(size_t dimension = 0)() return scope @trusted @property const
             if (dimension == 0)
         {
             assert(!empty!dimension);
@@ -1498,7 +1498,7 @@ public:
         }
 
         ///ditto
-        auto ref front(size_t dimension = 0)() scope return @trusted @property immutable
+        auto ref front(size_t dimension = 0)() return scope @trusted @property immutable
             if (dimension == 0)
         {
             assert(!empty!dimension);
@@ -1508,7 +1508,7 @@ public:
     else
     {
         /// ditto
-        Element!dimension front(size_t dimension = 0)() scope return @property
+        Element!dimension front(size_t dimension = 0)() return scope @property
             if (dimension < N)
         {
             typeof(return)._Structure structure_ = typeof(return)._Structure.init;
@@ -1534,7 +1534,7 @@ public:
         }
 
         ///ditto
-        auto front(size_t dimension = 0)() scope return @trusted @property const
+        auto front(size_t dimension = 0)() return scope @trusted @property const
             if (dimension < N)
         {
             assert(!empty!dimension);
@@ -1542,7 +1542,7 @@ public:
         }
 
         ///ditto
-        auto front(size_t dimension = 0)() scope return @trusted @property immutable
+        auto front(size_t dimension = 0)() return scope @trusted @property immutable
             if (dimension < N)
         {
             assert(!empty!dimension);
@@ -1553,7 +1553,7 @@ public:
     static if (N == 1 && isMutable!DeepElement && !hasAccessByRef)
     {
         ///ditto
-        auto ref front(size_t dimension = 0, T)(T value) scope return @trusted @property
+        auto ref front(size_t dimension = 0, T)(T value) return scope @trusted @property
             if (dimension == 0)
         {
             // check assign safety
@@ -1572,7 +1572,7 @@ public:
     ///ditto
     static if (N == 1)
     auto ref Element!dimension
-    back(size_t dimension = 0)() scope return @trusted @property
+    back(size_t dimension = 0)() return scope @trusted @property
         if (dimension < N)
     {
         assert(!empty!dimension);
@@ -1580,7 +1580,7 @@ public:
     }
     else
     auto ref Element!dimension
-    back(size_t dimension = 0)() scope return @trusted @property
+    back(size_t dimension = 0)() return scope @trusted @property
         if (dimension < N)
     {
         assert(!empty!dimension);
@@ -1609,7 +1609,7 @@ public:
     static if (N == 1 && isMutable!DeepElement && !hasAccessByRef)
     {
         ///ditto
-        auto ref back(size_t dimension = 0, T)(T value) scope return @trusted @property
+        auto ref back(size_t dimension = 0, T)(T value) return scope @trusted @property
             if (dimension == 0)
         {
             // check assign safety
@@ -1734,7 +1734,7 @@ public:
     static if (N > 1)
     {
         /// Accesses the first deep element of the slice.
-        auto ref first()() scope return @trusted @property
+        auto ref first()() return scope @trusted @property
         {
             assert(!anyEmpty);
             return *_iterator;
@@ -1742,7 +1742,7 @@ public:
 
         static if (isMutable!DeepElement && !hasAccessByRef)
         ///ditto
-        auto ref first(T)(T value) scope return @trusted @property
+        auto ref first(T)(T value) return scope @trusted @property
         {
             assert(!anyEmpty);
             static if (__traits(compiles, *_iterator = value))
@@ -1761,7 +1761,7 @@ public:
         }
 
         /// Accesses the last deep element of the slice.
-        auto ref last()() @trusted scope return @property
+        auto ref last()() @trusted return scope @property
         {
             assert(!anyEmpty);
             return _iterator[lastIndex];
@@ -1769,7 +1769,7 @@ public:
 
         static if (isMutable!DeepElement && !hasAccessByRef)
         ///ditto
-        auto ref last(T)(T value) @trusted scope return @property
+        auto ref last(T)(T value) @trusted return scope @property
         {
             assert(!anyEmpty);
             return _iterator[lastIndex] = value;
@@ -1869,7 +1869,7 @@ public:
 
     Returns: `this[$-index[0], $-index[1], ..., $-index[N-1]]`
     +/
-    auto ref backward()(size_t[N] index) scope return
+    auto ref backward()(size_t[N] index) return scope
     {
         foreach (i; Iota!N)
             index[i] = _lengths[i] - index[i];
@@ -1877,13 +1877,13 @@ public:
     }
 
     /// ditto
-    auto ref backward()(size_t[N] index) scope return const
+    auto ref backward()(size_t[N] index) return scope const
     {
         return this.lightConst.backward(index);
     }
 
     /// ditto
-    auto ref backward()(size_t[N] index) scope return const
+    auto ref backward()(size_t[N] index) return scope const
     {
         return this.lightConst.backward(index);
     }
@@ -1970,7 +1970,7 @@ public:
         n = count of elements for the dimension
     Returns: ndslice with `length!dimension` equal to `n`.
     +/
-    auto selectFront(size_t dimension)(size_t n) scope return
+    auto selectFront(size_t dimension)(size_t n) return scope
     {
         static if (kind == Contiguous && dimension)
         {
@@ -2002,7 +2002,7 @@ public:
         n = count of elements for the dimension
     Returns: ndslice with `length!dimension` equal to `n`.
     +/
-    auto selectBack(size_t dimension)(size_t n) scope return
+    auto selectBack(size_t dimension)(size_t n) return scope
     {
         static if (kind == Contiguous && dimension)
         {
@@ -2129,13 +2129,13 @@ public:
     /++
     $(BOLD Fully defined index)
     +/
-    auto ref opIndex()(size_t[N] _indices...) scope return @trusted
+    auto ref opIndex()(size_t[N] _indices...) return scope @trusted
     {
         return _iterator[indexStride(_indices)];
     }
 
     /// ditto
-    auto ref opIndex()(size_t[N] _indices...) scope return const @trusted
+    auto ref opIndex()(size_t[N] _indices...) return scope const @trusted
     {
         static if (is(typeof(_iterator[indexStride(_indices)])))
             return _iterator[indexStride(_indices)];
@@ -2144,7 +2144,7 @@ public:
     }
 
     /// ditto
-    auto ref opIndex()(size_t[N] _indices...) scope return immutable @trusted
+    auto ref opIndex()(size_t[N] _indices...) return scope immutable @trusted
     {
         static if (is(typeof(_iterator[indexStride(_indices)])))
             return _iterator[indexStride(_indices)];
@@ -2155,7 +2155,7 @@ public:
     /++
     $(BOLD Partially defined index)
     +/
-    auto opIndex(size_t I)(size_t[I] _indices...) scope return @trusted
+    auto opIndex(size_t I)(size_t[I] _indices...) return scope @trusted
         if (I && I < N)
     {
         enum size_t diff = N - I;
@@ -2167,14 +2167,14 @@ public:
     }
 
     /// ditto
-    auto opIndex(size_t I)(size_t[I] _indices...) scope return const
+    auto opIndex(size_t I)(size_t[I] _indices...) return scope const
         if (I && I < N)
     {
         return this.lightConst.opIndex(_indices);
     }
 
     /// ditto
-    auto opIndex(size_t I)(size_t[I] _indices...) scope return immutable
+    auto opIndex(size_t I)(size_t[I] _indices...) return scope immutable
         if (I && I < N)
     {
         return this.lightImmutable.opIndex(_indices);
@@ -2183,7 +2183,7 @@ public:
     /++
     $(BOLD Partially or fully defined slice.)
     +/
-    auto opIndex(Slices...)(Slices slices) scope return @trusted
+    auto opIndex(Slices...)(Slices slices) return scope @trusted
         if (isPureSlice!Slices)
     {
         static if (Slices.length)
@@ -2295,7 +2295,7 @@ public:
     /++
     $(BOLD Indexed slice.)
     +/
-    auto opIndex(Slices...)(scope return Slices slices) scope return
+    auto opIndex(Slices...)(return scope Slices slices) return scope
         if (isIndexedSlice!Slices)
     {
         import mir.ndslice.topology: indexed, cartesian;
@@ -2376,7 +2376,7 @@ public:
     Note:
         Does not allocate neither new slice nor a closure.
     +/
-    auto opUnary(string op)() scope return
+    auto opUnary(string op)() return scope
         if (op == "*" || op == "~" || op == "-" || op == "+")
     {
         import mir.ndslice.topology: map;
@@ -2412,7 +2412,7 @@ public:
     Note:
         Does not allocate neither new slice nor a closure.
     +/
-    auto opBinary(string op, T)(scope return T value) scope return
+    auto opBinary(string op, T)(scope return T value) return scope
         if(!isSlice!T)
     {
         import mir.ndslice.topology: vmap;
@@ -2420,7 +2420,7 @@ public:
     }
 
     /// ditto
-    auto opBinaryRight(string op, T)(scope return T value) scope return
+    auto opBinaryRight(string op, T)(scope return T value) return scope
         if(!isSlice!T)
     {
         import mir.ndslice.topology: vmap;
@@ -2465,7 +2465,7 @@ public:
         Does not allocate neither new slice nor a closure.
     +/
     auto opBinary(string op, RIterator, size_t RN, SliceKind rkind)
-        (scope return Slice!(RIterator, RN, rkind) rhs) scope return
+        (scope return Slice!(RIterator, RN, rkind) rhs) return scope
         if(N == RN && (kind == Contiguous && rkind == Contiguous || N == 1) && op != "~")
     {
         import mir.ndslice.topology: zip, map;
@@ -2641,7 +2641,7 @@ public:
         value of flattened slice at `index`
     See_also: $(SUBREF topology, flattened)
     +/
-    auto ref accessFlat(size_t index) scope return @trusted
+    auto ref accessFlat(size_t index) return scope @trusted
     {
         return _iterator[indexStrideValue(index)];
     }
@@ -2716,7 +2716,7 @@ public:
         Assignment of a value of `Slice` type to a $(B fully defined slice).
         +/
         void opIndexAssign(RIterator, size_t RN, SliceKind rkind, Slices...)
-            (Slice!(RIterator, RN, rkind) value, Slices slices) scope return
+            (Slice!(RIterator, RN, rkind) value, Slices slices) return scope
             if (isFullPureSlice!Slices || isIndexedSlice!Slices)
         {
             auto sl = this.lightScope.opIndex(slices);
@@ -2840,7 +2840,7 @@ public:
         /++
         Assignment of a regular multidimensional array to a $(B fully defined slice).
         +/
-        void opIndexAssign(T, Slices...)(T[] value, Slices slices) scope return
+        void opIndexAssign(T, Slices...)(T[] value, Slices slices) return scope
             if ((isFullPureSlice!Slices || isIndexedSlice!Slices)
                 && (!isDynamicArray!DeepElement || isDynamicArray!T)
                 && DynamicArrayDimensionsCount!(T[]) - DynamicArrayDimensionsCount!DeepElement <= typeof(this.opIndex(slices)).N)
@@ -2922,7 +2922,7 @@ public:
         }
 
         ///
-        void opIndexAssign(T, Slices...)(T concatenation, Slices slices) scope return
+        void opIndexAssign(T, Slices...)(T concatenation, Slices slices) return scope
             if ((isFullPureSlice!Slices || isIndexedSlice!Slices) && isConcatenation!T)
         {
             auto sl = this.lightScope.opIndex(slices);
@@ -2997,7 +2997,7 @@ public:
         /++
         Assignment of a value (e.g. a number) to a $(B fully defined index).
         +/
-        auto ref opIndexAssign(T)(T value, size_t[N] _indices...) scope return @trusted
+        auto ref opIndexAssign(T)(T value, size_t[N] _indices...) return scope @trusted
         {
             // check assign safety
             static auto ref fun(ref DeepElement t, ref T v) @safe
@@ -3007,7 +3007,7 @@ public:
             return _iterator[indexStride(_indices)] = value;
         }
         ///ditto
-        auto ref opIndexAssign()(DeepElement value, size_t[N] _indices...) scope return @trusted
+        auto ref opIndexAssign()(DeepElement value, size_t[N] _indices...) return scope @trusted
         {
             import mir.functional: forward;
             // check assign safety
@@ -3041,7 +3041,7 @@ public:
         /++
         Op Assignment `op=` of a value (e.g. a number) to a $(B fully defined index).
         +/
-        auto ref opIndexOpAssign(string op, T)(T value, size_t[N] _indices...) scope return @trusted
+        auto ref opIndexOpAssign(string op, T)(T value, size_t[N] _indices...) return scope @trusted
         {
             // check op safety
             static auto ref fun(ref DeepElement t, ref T v) @safe
@@ -3082,7 +3082,7 @@ public:
         Op Assignment `op=` of a value of `Slice` type to a $(B fully defined slice).
         +/
         void opIndexOpAssign(string op, RIterator, SliceKind rkind, size_t RN, Slices...)
-            (Slice!(RIterator, RN, rkind) value, Slices slices) scope return
+            (Slice!(RIterator, RN, rkind) value, Slices slices) return scope
             if (isFullPureSlice!Slices || isIndexedSlice!Slices)
         {
             auto sl = this.lightScope.opIndex(slices);
@@ -3147,7 +3147,7 @@ public:
         /++
         Op Assignment `op=` of a regular multidimensional array to a $(B fully defined slice).
         +/
-        void opIndexOpAssign(string op, T, Slices...)(T[] value, Slices slices) scope return
+        void opIndexOpAssign(string op, T, Slices...)(T[] value, Slices slices) return scope
             if (isFullPureSlice!Slices
                 && (!isDynamicArray!DeepElement || isDynamicArray!T)
                 && DynamicArrayDimensionsCount!(T[]) - DynamicArrayDimensionsCount!DeepElement <= typeof(this.opIndex(slices)).N)
@@ -3193,7 +3193,7 @@ public:
                      [2, 2, 3, 3]]);
         }
 
-        private void opIndexOpAssignImplValue(string op, T)(T value) scope return
+        private void opIndexOpAssignImplValue(string op, T)(T value) return scope
         {
             static if (N > 1 && kind == Contiguous)
             {
@@ -3223,7 +3223,7 @@ public:
         /++
         Op Assignment `op=` of a value (e.g. a number) to a $(B fully defined slice).
        +/
-        void opIndexOpAssign(string op, T, Slices...)(T value, Slices slices) scope return
+        void opIndexOpAssign(string op, T, Slices...)(T value, Slices slices) return scope
             if ((isFullPureSlice!Slices || isIndexedSlice!Slices)
                 && (!isDynamicArray!T || isDynamicArray!DeepElement)
                 && DynamicArrayDimensionsCount!T == DynamicArrayDimensionsCount!DeepElement
@@ -3253,7 +3253,7 @@ public:
         }
 
         ///
-        void opIndexOpAssign(string op,T, Slices...)(T concatenation, Slices slices) scope return
+        void opIndexOpAssign(string op,T, Slices...)(T concatenation, Slices slices) return scope
             if ((isFullPureSlice!Slices || isIndexedSlice!Slices) && isConcatenation!T)
         {
             auto sl = this.lightScope.opIndex(slices);
@@ -3277,7 +3277,7 @@ public:
         /++
         Increment `++` and Decrement `--` operators for a $(B fully defined index).
         +/
-        auto ref opIndexUnary(string op)(size_t[N] _indices...) scope return
+        auto ref opIndexUnary(string op)(size_t[N] _indices...) return scope
             @trusted
             // @@@workaround@@@ for Issue 16473
             //if (op == `++` || op == `--`)
@@ -3341,7 +3341,7 @@ public:
         /++
         Increment `++` and Decrement `--` operators for a $(B fully defined slice).
         +/
-        void opIndexUnary(string op, Slices...)(Slices slices) scope return
+        void opIndexUnary(string op, Slices...)(Slices slices) return scope
             if (isFullPureSlice!Slices && (op == `++` || op == `--`))
         {
             auto sl = this.lightScope.opIndex(slices);

--- a/source/mir/rc/array.d
+++ b/source/mir/rc/array.d
@@ -27,7 +27,7 @@ struct mir_rcarray(T)
     import mir.internal.utility: isComplex, realType;
     ///
     package T* _payload;
-    package ref mir_rc_context context() inout scope return pure nothrow @nogc @trusted @property
+    package ref mir_rc_context context() inout return scope pure nothrow @nogc @trusted @property
     {
         assert(_payload);
         return (cast(mir_rc_context*)_payload)[-1];
@@ -577,7 +577,7 @@ struct mir_rci(T)
     }
 
     ///
-    inout(T)* lightScope()() scope return inout @property @trusted
+    inout(T)* lightScope()() return scope inout @property @trusted
     {
         debug
         {
@@ -615,15 +615,15 @@ struct mir_rci(T)
     }
 
     ///
-    mir_rci!(const T) lightConst()() scope return const nothrow @property
+    mir_rci!(const T) lightConst()() return scope const nothrow @property
     { return typeof(return)(_iterator, _array.lightConst); }
 
     ///
-    mir_rci!(immutable T) lightImmutable()() scope return immutable nothrow @property
+    mir_rci!(immutable T) lightImmutable()() return scope immutable nothrow @property
     { return typeof(return)(_iterator, _array.lightImmutable); }
 
     ///
-    ref inout(T) opUnary(string op : "*")() inout scope return
+    ref inout(T) opUnary(string op : "*")() inout return scope
     {
         debug
         {
@@ -636,7 +636,7 @@ struct mir_rci(T)
     }
 
     ///
-    ref inout(T) opIndex(ptrdiff_t index) inout scope return @trusted
+    ref inout(T) opIndex(ptrdiff_t index) inout return scope @trusted
     {
         debug
         {

--- a/source/mir/rc/context.d
+++ b/source/mir/rc/context.d
@@ -176,15 +176,15 @@ mir_rc_context* mir_rc_create(
 package mixin template CommonRCImpl()
 {
     ///
-    ThisTemplate!(const T) lightConst()() scope return const @nogc nothrow @trusted @property
+    ThisTemplate!(const T) lightConst()() return scope const @nogc nothrow @trusted @property
     { return *cast(typeof(return)*) &this; }
 
     /// ditto
-    ThisTemplate!(immutable T) lightImmutable()() scope return immutable @nogc nothrow @trusted @property
+    ThisTemplate!(immutable T) lightImmutable()() return scope immutable @nogc nothrow @trusted @property
     { return *cast(typeof(return)*) &this; }
 
     ///
-    ThisTemplate!(const Unqual!T) moveToConst()() scope return @nogc nothrow @trusted @property
+    ThisTemplate!(const Unqual!T) moveToConst()() return scope @nogc nothrow @trusted @property
     {
         import core.lifetime: move;
         return move(*cast(typeof(return)*) &this);

--- a/source/mir/rc/ptr.d
+++ b/source/mir/rc/ptr.d
@@ -39,7 +39,7 @@ struct mir_rcptr(T)
         package T* _value;
     package mir_rc_context* _context;
 
-    package ref mir_rc_context context() inout scope return @trusted @property
+    package ref mir_rc_context context() inout return scope @trusted @property
     {
         return *cast(mir_rc_context*)_context;
     }
@@ -50,7 +50,7 @@ struct mir_rcptr(T)
         _context = null;
     }
 
-    inout(void)* _thisPtr() inout scope return @trusted @property
+    inout(void)* _thisPtr() inout return scope @trusted @property
     {
         return cast(inout(void)*) _value;
     }

--- a/source/mir/rc/slim_ptr.d
+++ b/source/mir/rc/slim_ptr.d
@@ -36,7 +36,7 @@ struct mir_slim_rcptr(T)
     else
         package T* _value;
 
-    package ref mir_rc_context context() inout scope return pure nothrow @nogc @trusted @property
+    package ref mir_rc_context context() inout return scope pure nothrow @nogc @trusted @property
     {
         assert(_value);
         return (cast(mir_rc_context*)_value)[-1];
@@ -47,7 +47,7 @@ struct mir_slim_rcptr(T)
         _value = null;
     }
 
-    inout(void)* _thisPtr() inout scope return @trusted @property
+    inout(void)* _thisPtr() inout return scope @trusted @property
     {
         return cast(inout(void)*) _value;
     }

--- a/source/mir/small_array.d
+++ b/source/mir/small_array.d
@@ -238,7 +238,7 @@ template SmallArray(T, uint maxLength)
         }
 
         ///
-        ref inout(T) opIndex(size_t index) inout scope return
+        ref inout(T) opIndex(size_t index) inout return scope
         {
             return opIndex[index];
         }

--- a/source/mir/small_string.d
+++ b/source/mir/small_string.d
@@ -207,7 +207,7 @@ scope nothrow:
 
     The method implement with `[]` operation.
     +/
-    inout(char)[] opIndex() inout @trusted scope return
+    inout(char)[] opIndex() inout @trusted return scope
     {
         size_t i;
         if (__ctfe)
@@ -218,7 +218,7 @@ scope nothrow:
     }
 
     ///
-    ref inout(char) opIndex(size_t index) inout scope return
+    ref inout(char) opIndex(size_t index) inout return scope
     {
         return opIndex[index];
     }
@@ -228,7 +228,7 @@ scope nothrow:
 
     The method implement with `[i .. j]` operation.
     +/
-    inout(char)[] opIndex(size_t[2] range) inout @trusted scope return
+    inout(char)[] opIndex(size_t[2] range) inout @trusted return scope
     in (range[0] <= range[1])
     in (range[1] <= this.length)
     {


### PR DESCRIPTION
---
1. When building mir-algorithm there is a new deprecation warning:
```
mir-algorithm/source/mir/appender.d(219,16): Deprecation: returning `this._buffer.length ? this._buffer[0..this._currentLength] : this._scopeBuffer()[0..this._currentLength]` escapes a reference to parameter `this`
mir-algorithm/source/mir/appender.d(217,16):        perhaps change the `return scope` into `scope return`
```
Fixed by annotating the `ScopedBuffer.data()` property with `return`.

---
2. When building a program using `-dip1000` that uses `mir.ndslice.sorting`, there is a new error:
```
mir-algorithm/source/mir/ndslice/sorting.d(157,30): Error: escaping reference to stack allocated value returned by `sort(sliced(ar))`
```
Fixed by swapping `scope return` for `return scope` in `mir_slice.field()`, which then propagated new errors in `mir_slice.lightConst()` and `mir_slice.lightImmutable()`:
```
mir-algorithm/source/mir/bignum/low_level_view.d(1328,18): Error: address of struct temporary returned by `this.lightConst()` assigned to longer lived variable `d`
```
... and then `BigUIntView.get()`, etc... at which point I've just mechanically replaced all occurrences of `scope return` function attributes with `return scope`.

Library now builds cleanly using current stable for upcoming v2.100.0 release.