### PR TITLE
Add logBinomial

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,7 @@ dependency "mir-core" version=">=1.1.106"
 
 buildType "unittest" {
     buildOptions "unittests" "debugMode" "debugInfo"
-    // versions "mir_bignum_test" "mir_ndslice_test" "mir_test"
+    versions "mir_bignum_test" "mir_ndslice_test" "mir_test"
     dflags "-lowmem"
 }
 buildType "unittest-dip1008" {


### PR DESCRIPTION
This is useful for `mir-stat` and fits in with `mir.combinatorics`. I wanted to use similar signature as `binomial`, though since `binomial` allows for negative results, this doesn't work with logs, so there are some differences. I simplify the formula so that  when k is close to n or 1 it should calculate faster.

I followed the approach described [here](https://www.johndcook.com/blog/2010/08/16/how-to-compute-log-factorial/) to save the first 256 values of log factorial to a table to load. They recommend then using an approximation, but I found that calculating it directly did a little bit better with compiling with ldc -O until the size gets larger and then I switch to log gamma from phobos (I generally refer precise calculations to approximate ones...). 

I'm flexible on the table approach. I used a static array at compile-time. dstats takes a similar approach, but they use a dynamic array. I used a smaller lookup. Not sure what difference it makes for memory usage. In my benchmarking, the table lookup is much faster, as you would expect.