### PR TITLE
Add additional filter UT example

### DIFF
--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -4096,6 +4096,27 @@ version(mir_test)
     assert(equal!equal(rc, [ [3, 100], [], [400, 102] ]));
 }
 
+/// N-dimensional filtering based on value in specific row/column
+version(mir_test)
+@safe pure
+unittest
+{
+    import mir.ndslice.fuse;
+    import mir.ndslice.topology: byDim;
+
+    auto matrix =
+    [[   3,   2, 400 ],
+     [ 100, -101, 102 ]].fuse;
+
+    // filter row based on value in index 1
+    auto r1 = matrix.byDim!0.filter!("a[1] > 0");
+    assert(equal!equal(r1, [ [3, 2, 400] ]));
+
+    // filter column based on value in index 1
+    auto r2 = matrix.byDim!1.filter!("a[1] > 0");
+    assert(equal!equal(r2, [ [3, 100], [400, 102] ]));
+}
+
 /// Filter out NaNs
 version(mir_test)
 @safe pure nothrow

--- a/source/mir/algorithm/iteration.d
+++ b/source/mir/algorithm/iteration.d
@@ -4127,8 +4127,10 @@ unittest {
     double x;
     auto y = [[1.0, 2, x], [3.0, 4, 5]].fuse;
 
+    // by row
     auto z1 = y.byDim!0.map!(filter!(a => !isNaN(a)));
     assert(z1.equal!equal(result1));
+    // by column
     auto z2 = y.byDim!1.map!(filter!(a => !isNaN(a)));
     assert(z2.equal!equal(result2));
 }
@@ -4148,8 +4150,10 @@ unittest {
     double x;
     auto y = [[1.0, 2, x], [3.0, 4, 5]].fuse;
 
+    // by row
     auto z1 = y.byDim!0.filter!(a => a.all!(b => !isNaN(b)));
     assert(z1.equal!equal(result1));
+    // by column
     auto z2 = y.byDim!1.filter!(a => a.all!(b => !isNaN(b)));
     assert(z2.equal!equal(result2));
 }


### PR DESCRIPTION
This adds an additional UT example for the case where you want to filter a slice based on a particular row or column. This idiom is very common in `dplyr`/`pandas`. 

One thing that would make this even easier for the Data Frame case is if there were an easy way to index or select by label. For instance, in the example here [1], `dataframe["balance"]` or `dataframe.select!1("balance")` or something like that would return the column associated with the "balance" label. 

[1] http://mir-algorithm.libmir.org/mir_ndslice_allocation.html#.slice