### PR TITLE
Don't depend on `stringof` in `mir.parse` test

### DIFF
--- a/source/mir/parse.d
+++ b/source/mir/parse.d
@@ -381,6 +381,7 @@ version (mir_test) unittest
 version (mir_test) unittest
 {
     import mir.test: should;
+    import mir.conv: to;
     import std.meta: AliasSeq;
     foreach (T; AliasSeq!(byte, short, int, long))
     {
@@ -396,7 +397,7 @@ version (mir_test) unittest
         val.should == -9;
         assert(str == "text");
         enum m = T.min + 0;
-        str = m.stringof;
+        str = m.to!string;
         assert(parse(str, val));
         val.should == T.min;
     }


### PR DESCRIPTION
This is blocking https://github.com/dlang/dmd/pull/14218

Depending on the specific output of `.stringof` is bad practice, like the spec says:

> Implementation Defined: The string representation for a type or expression can vary.

