### PR TITLE
Fix `dub build --build=docs` or `dub build --build=ddox`

### DIFF
--- a/source/mir/bignum/internal/phobos_kernel.d
+++ b/source/mir/bignum/internal/phobos_kernel.d
@@ -751,10 +751,10 @@ size_t biguintToOctal(char[] buff, const(BigDigit)[] data)
 /** Convert a big uint into a decimal string.
  *
  * Params:
- *  data    The biguint to be converted. Will be destroyed.
- *  buff    The destination buffer for the decimal string. Must be
- *          large enough to store the result, including leading zeros.
- *          Will be filled backwards, starting from buff[$-1].
+ *  buff = The destination buffer for the decimal string. Must be
+ *      large enough to store the result, including leading zeros.
+ *      Will be filled backwards, starting from buff[$-1].
+ *  data = The biguint to be converted. Will be destroyed.
  *
  * buff.length must be >= (data.length*32)/log2(10) = 9.63296 * data.length.
  * Returns:
@@ -787,9 +787,9 @@ size_t biguintToDecimal(char [] buff, BigDigit [] data) pure nothrow @safe
 /** Convert a decimal string into a big uint.
  *
  * Params:
- *  data    The biguint to be receive the result. Must be large enough to
- *          store the result.
- *  s       The decimal string. May contain _ or 0 .. 9
+ *  data = The biguint to be receive the result. Must be large enough to
+ *      store the result.
+ *  s = The decimal string. May contain _ or 0 .. 9
  *
  * The required length for the destination buffer is slightly less than
  *  1 + s.length/log2(10) = 1 + s.length/3.3219.

--- a/source/mir/math/numeric.d
+++ b/source/mir/math/numeric.d
@@ -606,8 +606,6 @@ Quickly computes binomial coefficient using extended
 precision floating point type $(MREF mir,bignum,fp).
 
 Params:
-    DivisionType = the type used for a single division at the final.
-        By defualt, uses `real` precision. TODO: full `Fp` precision.
     n = number elements in the set 
     k = number elements in the subset 
 Returns: n choose k

--- a/source/mir/numeric.d
+++ b/source/mir/numeric.d
@@ -1561,7 +1561,10 @@ Params:
     fbx = Value of `f(bx)` (optional).
     relTolerance = Relative tolerance used by $(LREF findLocalMin).
     absTolerance = Absolute tolerance used by $(LREF findLocalMin).
+    lowerBound = 
+    upperBound =
     maxIterations = Appr. maximum allowed number of function calls for each $(LREF findRoot) call.
+    steps = 
 
 Returns: $(LREF FindSmileRootsResult)
 +/


### PR DESCRIPTION
This is a mixed bag commit:
- phobos_kernel.d: ddoc syntax
- mir/math/numeric.d: just removed DivisionType as its also not documented in
  factorial
- mir/numeric.d: just added empty docs for lowerBound, upperBound,
  steps. Some of those are not used at all in the function.