### PR TITLE
Adjust test for pow() computed at double precision

### DIFF
--- a/source/mir/ediff.d
+++ b/source/mir/ediff.d
@@ -139,7 +139,7 @@ unittest
     auto f1 = exp(3.Const * spot.powi!(-2));
     static assert(Dependencies!(typeof(f1)) == ["spot"].DependsOn);
     assert(f1.getFunctionValue == mir.math.exp(3 * 7.0 ^^ -2));
-    assert(f1.getDerivative!(["spot"]) == 3 * -2 * 7.0 ^^ -3 * mir.math.exp(3 * 7.0 ^^ -2));
+    assert(f1.getDerivative!(["spot"]).approxEqual(3 * -2 * 7.0 ^^ -3 * mir.math.exp(3 * 7.0 ^^ -2)));
     // Test DerivativeOf
     assert(f1.derivativeOf!"spot".getFunctionValue == f1.getDerivative!(["spot"]));
     // Test product and sum


### PR DESCRIPTION
New overloads for pow and logN will be added in dlang/phobos#8492 and dlang/phobos#8499, this prepares this repository for the change.

That this test fails as a result of the change also indicates it would also fail on real == double targets.