### PR TITLE
Add `between` member function to date structs

### DIFF
--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -1290,8 +1290,7 @@ enum Quarter : short
 Returns the quarter for a given month.
 
 Params:
-    month
-
+    month = month to match with quarter
 +/
 @safe pure @nogc nothrow
 Quarter quarter(Month month)


### PR DESCRIPTION
I want to add a `period` function that produces a slice between two dates or lengths (kind of similar to `iota` or `linspace` but for dates. These functions are likely a prerequisite and useful regardless. 