### PR TITLE
Add mir.date.d operator overloading, UTs

### DIFF
--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -1027,10 +1027,13 @@ nothrow:
     alias opBinaryRight(string op : "+") = opBinary!"+";
 
     ///
-    ref YearMonth opOpAssign(string op)(int lhs) return @safe pure nothrow @nogc
+    ref YearMonth opOpAssign(string op)(int rhs) return @safe pure nothrow @nogc
         if (op == "+" || op == "-")
     {
-        mixin("this = addMonths(" ~ op ~ "lhs);");
+        static if (op == "+")
+           this = addMonths(rhs);
+        else
+           this = addMonths(-rhs);
         return this;
     }
 
@@ -1515,10 +1518,13 @@ struct YearQuarter
     alias opBinaryRight(string op : "+") = opBinary!"+";
 
     ///
-    ref YearQuarter opOpAssign(string op)(int lhs) return @safe pure nothrow @nogc
+    ref YearQuarter opOpAssign(string op)(int rhs) return @safe pure nothrow @nogc
         if (op == "+" || op == "-")
     {
-        mixin("this = addQuarters(" ~ op ~ "lhs);");
+        static if (op == "+")
+           this = addQuarters(rhs);
+        else
+           this = addQuarters(-rhs);
         return this;
     }
 
@@ -2666,10 +2672,13 @@ public:
     }
 
     ///
-    ref Date opOpAssign(string op)(int lhs) return @safe pure nothrow @nogc
+    ref Date opOpAssign(string op)(int rhs) return @safe pure nothrow @nogc
         if (op == "+" || op == "-")
     {
-        mixin("this._addDays(" ~ op ~ "lhs);");
+        static if (op == "+")
+           this._addDays(rhs);
+        else
+           this._addDays(-rhs);
         return this;
     }
     

--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -2648,27 +2648,27 @@ public:
     }
 
     ///
-    int opBinary(string op : "-")(Date lhs) const
+    int opBinary(string op : "-")(Date rhs) const
     {
-        return _julianDay - lhs._julianDay;
+        return _julianDay - rhs._julianDay;
     }
 
     ///
-    Date opBinary(string op : "+")(int lhs) const
+    Date opBinary(string op : "+")(int rhs) const
     {
-        return Date(_julianDay + lhs);
+        return Date(_julianDay + rhs);
     }
 
     ///
-    Date opBinaryRight(string op : "+")(int lhs) const
+    Date opBinaryRight(string op : "+")(int rhs) const
     {
-        return Date(_julianDay + lhs);
+        return Date(_julianDay + rhs);
     }
 
     ///
-    Date opBinary(string op : "-")(int lhs) const
+    Date opBinary(string op : "-")(int rhs) const
     {
-        return Date(_julianDay - lhs);
+        return Date(_julianDay - rhs);
     }
 
     ///

--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -857,6 +857,125 @@ struct YearMonth
 nothrow:
 
     ///
+    deprecated("please use addMonths instead")
+    @safe pure nothrow @nogc
+    ref YearMonth add(string units : "months")(long months)
+    {
+        auto years = months / 12;
+        months %= 12;
+        auto newMonth = month + months;
+
+        if (months < 0)
+        {
+            if (newMonth < 1)
+            {
+                newMonth += 12;
+                --years;
+            }
+        }
+        else if (newMonth > 12)
+        {
+            newMonth -= 12;
+            ++years;
+        }
+
+        year += years;
+        month = cast(Month) newMonth;
+
+        return this;
+    }
+
+    ///
+    version(mir_test_deprecated)
+    @safe unittest
+    {
+        auto ym0 = YearMonth(2020, Month.jan);
+
+        ym0.add!"months"(1);
+        assert(ym0.year == 2020);
+        assert(ym0.month == Month.feb);
+
+        auto ym1 = ym0.add!"months"(1);
+        assert(ym1.year == 2020);
+        assert(ym1.month == Month.mar);
+
+        // also changes ym0
+        assert(ym0.year == 2020);
+        assert(ym0.month == Month.mar);
+
+        ym1.add!"months"(10);
+        assert(ym1.year == 2021);
+        assert(ym1.month == Month.jan);
+
+        ym1.add!"months"(-13);
+        assert(ym1.year == 2019);
+        assert(ym1.month == Month.dec);
+    }
+
+    ///
+    deprecated("please use addQuarters instead")
+    @safe pure nothrow @nogc
+    ref YearMonth add(string units : "quarters")(long quarters)
+    {
+        return add!"months"(quarters * 3);
+    }
+
+    ///
+    version(mir_test_deprecated)
+    @safe unittest
+    {
+        auto yq0 = YearMonth(2020, Month.jan);
+
+        yq0.add!"quarters"(1);
+        assert(yq0.year == 2020);
+        assert(yq0.month == Month.apr);
+
+        auto yq1 = yq0.add!"quarters"(1);
+        assert(yq1.year == 2020);
+        assert(yq1.month == Month.jul);
+
+        // also changes yq0
+        assert(yq0.year == 2020);
+        assert(yq0.month == Month.jul);
+
+        yq1.add!"quarters"(2);
+        assert(yq1.year == 2021);
+        assert(yq1.month == Month.jan);
+
+        yq1.add!"quarters"(-5);
+        assert(yq1.year == 2019);
+        assert(yq1.month == Month.oct);
+    }
+
+    ///
+    deprecated("please use addYears instead")
+    @safe pure nothrow @nogc
+    ref YearMonth add(string units : "years")(long years)
+    {
+        year += years;
+        return this;
+    }
+
+    ///
+    version(mir_test_deprecated)
+    @safe unittest
+    {
+        auto ym0 = YearMonth(2020, Month.jan);
+
+        ym0.add!"years"(1);
+        assert(ym0.year == 2021);
+        assert(ym0.month == Month.jan);
+
+        auto ym1 = ym0.add!"years"(1);
+        assert(ym1.year == 2022);
+        assert(ym1.month == Month.jan);
+
+        // also changes ym0
+        assert(ym0.year == 2022);
+        assert(ym0.month == Month.jan);
+    }
+
+    ///
     @safe pure nothrow @nogc
     YearMonth addMonths(long months)
     {
@@ -1375,6 +1494,90 @@ struct YearQuarter
         import mir.timestamp;
         auto ts = Timestamp(2020, 4);
         auto yq = YearQuarter(ts);
+    }
+
+    ///
+    deprecated("please use addQuarters instead")
+    @safe pure nothrow @nogc
+    ref YearQuarter add(string units : "quarters")(long quarters)
+    {
+        auto years = quarters / 4;
+        quarters %= 4;
+        auto newQuarter = quarter + quarters;
+
+        if (quarters < 0)
+        {
+            if (newQuarter < 1)
+            {
+                newQuarter += 4;
+                --years;
+            }
+        }
+        else if (newQuarter > 4)
+        {
+            newQuarter -= 4;
+            ++years;
+        }
+
+        year += years;
+        quarter = cast(Quarter) newQuarter;
+
+        return this;
+    }
+
+    ///
+    version(mir_test_deprecated)
+    @safe unittest
+    {
+        auto yq0 = YearQuarter(2020, Quarter.q1);
+
+        yq0.add!"quarters"(1);
+        assert(yq0.year == 2020);
+        assert(yq0.quarter == Quarter.q2);
+
+        auto yq1 = yq0.add!"quarters"(1);
+        assert(yq1.year == 2020);
+        assert(yq1.quarter == Quarter.q3);
+
+        // also changes yq0
+        assert(yq0.year == 2020);
+        assert(yq0.quarter == Quarter.q3);
+
+        yq1.add!"quarters"(2);
+        assert(yq1.year == 2021);
+        assert(yq1.quarter == Quarter.q1);
+
+        yq1.add!"quarters"(-5);
+        assert(yq1.year == 2019);
+        assert(yq1.quarter == Quarter.q4);
+    }
+
+    ///
+    deprecated("please use addYears instead")
+    @safe pure nothrow @nogc
+    ref YearQuarter add(string units : "years")(long years)
+    {
+        year += years;
+        return this;
+    }
+
+    ///
+    version(mir_test_deprecated)
+    @safe unittest
+    {
+        auto yq0 = YearQuarter(2020, Quarter.q1);
+
+        yq0.add!"years"(1);
+        assert(yq0.year == 2021);
+        assert(yq0.quarter == Quarter.q1);
+
+        auto yq1 = yq0.add!"years"(1);
+        assert(yq1.year == 2022);
+        assert(yq1.quarter == Quarter.q1);
+
+        // also changes yq0
+        assert(yq0.year == 2022);
+        assert(yq0.quarter == Quarter.q1);
     }
 
     ///

--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -1168,7 +1168,7 @@ enum Quarter : short
 Returns the quarter for a given month.
 
 Params:
-    month
+    month = month
 
 +/
 @safe pure @nogc nothrow

--- a/source/mir/date.d
+++ b/source/mir/date.d
@@ -2715,7 +2715,7 @@ public:
         assert(a == result4);
 
         // every year
-        auto b = (d.YearMonth + iota!uint([4], 0, 12)).map!Date;
+        auto b = (d.year + 4.iota!uint).map!(a => YearMonthDay(cast(short) a, Month.mar, 1).Date);
         assert(b == result5);
     }
 


### PR DESCRIPTION
An alternative to PR #436 based on some of the discussion there. 

I remove the add!"X" from `YearMonth` and `YearQuarter` (leaving it for `YearMonthDay` and `Date`). I set up `opBinary` and `opOpAssign` for them as well. I also provide some additional UT examples.

One thing to be aware of is that if you convert a `Date` to a `YearMonth` or `YearQuarter` and then back to a `Date`, there can be some tricky things happening with getting the dates back to how they should be. <s>It's less complicated for my examples because I start them on the first of the month, but if you want everything as of the 10th of the month, then it requires some additional cleanup afterward with this `iota` approach. </s> I added another commit fixing the year example in `Date` so that it is a little bit simpler, but it may not be so intuitive to a new user. 