### PR TITLE
Fix github actions button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![codecov.io](https://codecov.io/github/libmir/mir-algorithm/coverage.svg?branch=master)](https://codecov.io/github/libmir/mir-algorithm?branch=master)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/libmir/mir-algorithm/CI/master)](https://github.com/libmir/mir-algorithm/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/algorithmus/libmir/mir-algorithm/ci.yml?branch=master)](https://github.com/libmir/mir-algorithm/actions)
 [![Circle CI](https://circleci.com/gh/libmir/mir-algorithm.svg?style=svg)](https://circleci.com/gh/libmir/mir-algorithm)
 
 [![Dub downloads](https://img.shields.io/dub/dt/mir-algorithm.svg)](http://code.dlang.org/packages/mir-algorithm)


### PR DESCRIPTION
Adjusting the Github Action button code based on https://github.com/badges/shields/issues/8671

I did the same on mir-stat and it worked (the mir-algorithm version looks a little more complicated but I think the change should still work, open to changes). 