### PR TITLE
Adjust variance implementation and add new default hybrid algorithm

### DIFF
--- a/source/mir/math/stat.d
+++ b/source/mir/math/stat.d
@@ -9,7 +9,7 @@ License: $(HTTP www.apache.org/licenses/LICENSE-2.0, Apache-2.0)
 
 Authors: Shigeki Karita (original numir code), Ilia Ki, John Michael Hall
 
-Copyright: 2020 Ilia Ki, Kaleidic Associates Advisory Limited, Symmetry Investments
+Copyright: 2020-3 Ilia Ki, Kaleidic Associates Advisory Limited, Symmetry Investments
 
 Macros:
 SUBREF = $(REF_ALTTEXT $(TT $2), $2, mir, math, $1)$(NBSP)


### PR DESCRIPTION
This makes some adjustments to how variance is implemented and the unit tests and coverage. The more significant change is a new default hybrid algorithm that combines the nice parts about the twoPass and online algorithm. For the purpose of the variance calculation, it is basically the same as twoPass, but offers more flexibility for VarianceAccumulator.

The online algorithm turns out to be much slower than I expected in benchmarks. 