### PR TITLE
Avoid op= on struct rvalue

### DIFF
--- a/source/mir/bignum/fixed.d
+++ b/source/mir/bignum/fixed.d
@@ -963,7 +963,7 @@ UInt!(size + size_t.sizeof * 8)
     extendedMul(size_t size)(UInt!size a, size_t b)
     @safe pure nothrow @nogc
 {
-    size_t overflow = a.view *= b;
+    size_t overflow = a.view.opOpAssign!"*"(b);
     auto ret = a.toSize!(size + size_t.sizeof * 8);
     ret.data[$ - 1] = overflow;
     return ret;
@@ -1060,6 +1060,7 @@ UInt!(size + size_t.sizeof * 8)
 {
     auto ret = extendedMul(a, b);
     auto view = ret.view;
-    view.coefficients[$ - 1] += view.topLeastSignificantPart(a.data.length) += c.view;
+    view.coefficients[$ - 1] +=
+        view.topLeastSignificantPart(a.data.length).opOpAssign!"+"(c.view);
     return ret;
 }


### PR DESCRIPTION
I'm trying to make assigning to a struct rvalue an error, because often the assignment is silently thrown away:
https://github.com/dlang/dmd/pull/21717#issuecomment-3191656768

That breaks some buildkite projects, including this one - so it will probably be a deprecation/error in an edition. This PR avoids breaking this project.

Use `opOpAssign` directly instead, which is in the spec:

> an instance method can still be called on an rvalue struct instance,
even if the method is not const

https://dlang.org/spec/struct.html#member-functions

Alternatively, we could declare an lvalue for the temporary.